### PR TITLE
bcf/bug fix

### DIFF
--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -3846,7 +3846,7 @@ PeleLM::temperature_stats (MultiFab& S)
     Real tdhmin[3] = { 1.0e30, 1.0e30, 1.0e30};
     Real tdhmax[3] = {-1.0e30,-1.0e30,-1.0e30};
 #ifdef _OPENMP
-#pragma omp parallel
+#pragma omp parallel reduction(min:tdhmin[:3]) reduction(max:tdhmax[:3])
 #endif
     for (MFIter S_mfi(S,true); S_mfi.isValid(); ++S_mfi)
     {


### PR DESCRIPTION
Currently these variable are shared amongst threads and thus are subject to a
data race condition. Add an array reduction clause to each variable to compute
the min/max across all threads in the loop. Array reductions in C++ require a
compiler which supports OpenMP 4.5.