### PR TITLE
Add run-time managed refinement criteria, add documentation

### DIFF
--- a/Docs/source/ProblemSetup.rst
+++ b/Docs/source/ProblemSetup.rst
@@ -272,7 +272,7 @@ The third will be active only when the problem time is between 0.001 and 0.002 s
 
 Note that these additional user-created criteria operate in addition to those defined as defaults.  Also note that
 these can be modified between restarts of the code.  By default, the new criteria will take effect at the next
-schedule regrid operation.  Alternatively, the user may restart with ``amr.regrid_on_restart = 1`` in order to
+scheduled regrid operation.  Alternatively, the user may restart with ``amr.regrid_on_restart = 1`` in order to
 do a full (all-levels) regrid after reading the checkpoint data and before advancing any cells.
 
 

--- a/Docs/source/ProblemSetup.rst
+++ b/Docs/source/ProblemSetup.rst
@@ -220,7 +220,59 @@ overlaps the valid domain, the values set in the grow cells of the container wil
 boundary face of the corresponding cells.  Internally, all `PeleLM` code understands to apply
 Dirichlet conditions on the boundary faces.
 
+.. _sec:refcrit:pelelm:
+
 Refinement Criteria
 -------------------
 
-TODO: Add junk here for refinement criteria.
+The dynamic creation and destruction of grid levels is a fundamental part of `PeleLM`'s capabilities. The
+process for this is described in some detail in the `AMReX` documentation, but we summarize the key points
+here.
+
+At regular intervals (set by the user), each Amr level that is not the finest allowed for the run
+will invoke a "regrid" operation.  When invoked, a list of error tagging functions is traversed. For each,
+a field specific to that function is derived from the state over the level, and passed through a kernel
+that "set"'s or "clear"'s a flag on each cell.  The field and function for each error tagging quantity is
+identified in the setup phase of the code where the state descriptors are defined (i.e., in `PeleLM_setup.cpp`).
+Each function in the list adds or removes to the list of cells tagged for refinement. This final list of tagged
+cells is sent to a grid generation routine, which uses the Berger-Rigoutsos algorithm to create rectangular grids
+which will define a new finer level (or set of levels).  State data is filled over these new grids, copying where
+possible, and interpolating from coarser level when no fine data is available.  Once this process is complete,
+the existing Amr level(s) is removed, the new one is inserted into the hierarchy, and the time integration
+continues.
+
+The traditional `AMReX` approach to setting up and controlling the regrid process involves explicitly
+creating ("hard coding") a number of functions directly into `PeleLM`'s setup code. (Consult the source code
+and `AMReX` documentation for precisely how this is done).  `PeleLM` provides a limited capability to augment
+the standard set of error functions that is based entirely on runtime data specified in the inputs (ParmParse)
+data.  The following example portion of a ParmParse'd input file demonstrates the usage of this feature:
+
+::
+
+      amr.refinement_indicators = flame_tracer lo_temp gradT
+
+      amr.flame_tracer.max_level = 3
+      amr.flame_tracer.value_greater = 1.e-6
+      amr.flame_tracer.field_name = Y(H)
+
+      amr.lo_temp.max_level = 1
+      amr.lo_temp.value_less = 450
+      amr.lo_temp.field_name = temp
+
+      amr.gradT.max_level = 2
+      amr.gradT.adjacent_difference_greater = 20
+      amr.gradT.field_name = temp
+      amr.gradT.start_time = 0.001
+      amr.gradT.end_name = 0.002
+
+Here, we have added three new custom-named criteria -- ``flame_tracer``: cells with the mass fraction of H greater than 1 ppm;
+``lo_temp``: cells with T less than 450K, and ``gradT``: cells having a temperature difference of 20K from that of their
+immediate neighbor.  The first will trigger up to Amr level 3, the second only to level 1, and the third to level 2.
+The third will be active only when the problem time is between 0.001 and 0.002 seconds.
+
+Note that these additional user-created criteria operate in addition to those defined as defaults.  Also note that
+these can be modified between restarts of the code.  By default, the new criteria will take effect at the next
+schedule regrid operation.  Alternatively, the user may restart with ``amr.regrid_on_restart = 1`` in order to
+do a full (all-levels) regrid after reading the checkpoint data and before advancing any cells.
+
+

--- a/Docs/source/RunningPeleLM.rst
+++ b/Docs/source/RunningPeleLM.rst
@@ -189,7 +189,8 @@ Regridding
 
 The details of the regridding strategy are described elsewhere; here we 
 cover how the input parameters can control the gridding. The user defines functions which tag individual
-cells at a given level if they need refinement.  This list of tagged cells is
+cells at a given level if they need refinement (this is discussed in :ref:`sec:refcrit:pelelm`).
+This list of tagged cells is
 sent to a grid generation routine, which uses the Berger-Rigoutsos algorithm
 to create rectangular grids that contain the tagged cells. The relevant runtime parameters are:
 

--- a/Exec/CKLaw/MyProb_F.H
+++ b/Exec/CKLaw/MyProb_F.H
@@ -1,0 +1,37 @@
+#undef BL_LANG_CC
+#ifndef BL_LANG_FORT
+#define BL_LANG_FORT
+#endif
+
+#define SDIM BL_SPACEDIM
+
+#include <AMReX_REAL.H>
+#include <AMReX_CONSTANTS.H>
+#include <AMReX_BC_TYPES.H>
+#include <Prob_F.H>
+#include <AMReX_ArrayLim.H>
+#include <ChemDriver_F.H>
+#include <PeleLM_F.H>
+#if defined(BL_DO_FLCT)
+#include <infl_frc.H>
+#endif
+
+#define XLO 0
+#define YLO 1
+#define XHI 2
+#define YHI 3
+#define ZLO 4
+#define ZHI 5
+
+#define M_FUEL  1
+#define M_CO    2
+#define M_WALL  3
+
+      
+#define BL_FUELPIPE 1
+#define BL_COFLOW   2
+#define BL_STICK    3
+#define BL_WALL     4
+#define BL_AMBIENT  5
+#define BL_VOLUME   6
+#define BL_PIPEEND  7

--- a/Exec/CKLaw/Prob_F.F90
+++ b/Exec/CKLaw/Prob_F.F90
@@ -1,0 +1,31 @@
+
+#include <MyProb_F.H>
+
+module probspec_module
+
+  implicit none
+  
+  private
+  
+  public :: set_prob_spec            
+
+contains
+
+  subroutine set_prob_spec(fuel, oxid, prod, numspec) &
+                                bind(C, name="set_prob_spec")
+ 
+      implicit none
+#include <cdwrk.H>
+#include <probdata.H>
+      integer fuel, oxid, prod, numspec
+      fuelID = fuel + 1
+      oxidID = oxid + 1
+      prodID = prod + 1
+
+      if (numspec .ne. Nspec) then
+         call bl_pd_abort('number of species not consistent')
+      endif
+      
+  end subroutine set_prob_spec
+
+end module probspec_module

--- a/Exec/FlameInABox/inputs.2d-regt
+++ b/Exec/FlameInABox/inputs.2d-regt
@@ -177,3 +177,8 @@ fab.format = NATIVE
 
 fabarray.mfiter_tile_size = 8 8 8 
 amrex.regtest_reduction=1
+
+amr.refinement_indicators = flame_tracer
+amr.flame_tracer.max_level = 3
+amr.flame_tracer.value_greater = 1.e-6
+amr.flame_tracer.field_name = Y(H)

--- a/Exec/FlameInABox/inputs.3d-regt
+++ b/Exec/FlameInABox/inputs.3d-regt
@@ -174,3 +174,9 @@ mac.do_outflow_bcs = 0
 #   8BIT   (eight-bit run-length-encoded)
 #
 fab.format = NATIVE
+amrex.regtest_reduction=1
+
+amr.refinement_indicators = flame_tracer
+amr.flame_tracer.max_level = 3
+amr.flame_tracer.value_greater = 1.e-6
+amr.flame_tracer.field_name = Y(H)

--- a/Exec/FlameInABox/probdata.H
+++ b/Exec/FlameInABox/probdata.H
@@ -23,7 +23,6 @@
       save /prob1/, /prob2/, /prob3/, /prob4/, /prob5/
 
       integer refine_nozzle
-      REAL_T  jet_x, jet_y, adv_vel, infl_time_offset, omega
       REAL_T refine_nozzle_x, refine_nozzle_y, refine_nozzle_z, blobx, bloby, blobz, blobr, blobT, Tfrontw, xcen
       common /myprob1/ refine_nozzle
       common /myprob2/ refine_nozzle_x, refine_nozzle_y, refine_nozzle_z, blobx, bloby, blobz, &

--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -25,6 +25,56 @@
 //       multigrid code.
 //
 
+extern "C"
+{
+  typedef void (*LMEF)(int* tag, ARLIM_P(tlo), ARLIM_P(thi),
+                       const int* tagval, const int* clearval,
+                       const amrex::Real* data, ARLIM_P(data_lo), ARLIM_P(data_hi),
+                       const int* lo, const int* hi, const int* nvar,
+                       const int* domain_lo, const int* domain_hi,
+                       const amrex::Real* dx, const amrex::Real* xlo,
+                       const amrex::Real* prob_lo, const amrex::Real* time,
+                       const int* level, const amrex::Real* value);
+}
+
+class LM_Error_Value
+  :
+  public amrex::ErrorRec::ErrorFunc
+{
+public:
+  LM_Error_Value()
+    :
+    lmef(0), value(), min_time(), max_time(), max_level() {}
+  
+  LM_Error_Value (amrex::Real min_time, amrex::Real max_time, int max_level);
+  
+  LM_Error_Value (LMEF lmef, amrex::Real value, amrex::Real min_time,
+                  amrex::Real max_time, int max_level);
+  
+  virtual ~LM_Error_Value () {}
+  
+  virtual amrex::ErrorRec::ErrorFunc* clone () const {
+    return new LM_Error_Value(lmef,value,min_time,max_time,max_level);
+  }
+  
+  void tagCells(int* tag, ARLIM_P(tlo), ARLIM_P(thi),
+                const int* tagval, const int* clearval,
+                const amrex::Real* data, ARLIM_P(data_lo), ARLIM_P(data_hi),
+                const int* lo, const int* hi, const int* nvar,
+                const int* domain_lo, const int* domain_hi,
+                const amrex::Real* dx, const amrex::Real* xlo,
+                const amrex::Real* prob_lo, const amrex::Real* time,
+                const int* level) const;
+  int MaxLevel() const {return max_level;}
+  amrex::Real MinTime() const {return min_time;}
+  amrex::Real MaxTime() const {return max_time;}
+  amrex::Real Value() const {return value;}
+  
+protected:
+  LMEF lmef;
+  amrex::Real value, min_time, max_time;
+  int max_level;
+};
 
 class PeleLM
   :
@@ -201,6 +251,12 @@ protected:
 
   virtual void velocity_diffusion_update (amrex::Real dt) override;
 
+  virtual void errorEst (amrex::TagBoxArray& tags,
+                         int                 clearval,
+                         int                 tagval,
+                         amrex::Real         time,
+                         int                 n_error_buf, 
+                         int                 ngrow) override;
 
   ////////////////////////////////////////////////////////////////////////////
   //    PeleLM protected static functions                             //

--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -676,7 +676,40 @@ PeleLM::fpi_phys_loc (int p_bc)
   }
   return HT_Center;
 }
-    
+
+LM_Error_Value::LM_Error_Value (Real _min_time, Real _max_time, int _max_level)
+    : lmef(0), value(0), min_time(_min_time), max_time(_max_time), max_level(_max_level)
+{
+}
+
+LM_Error_Value::LM_Error_Value (LMEF _lmef,
+                                Real _value, Real _min_time,
+                                Real _max_time, int _max_level)
+    : lmef(_lmef), value(_value), min_time(_min_time), max_time(_max_time), max_level(_max_level)
+{
+}
+
+void
+LM_Error_Value::tagCells(int* tag, D_DECL(const int& tlo0,const int& tlo1,const int& tlo2),
+                         D_DECL(const int& thi0,const int& thi1,const int& thi2),
+                         const int* tagval, const int* clearval,
+                         const Real* data, 
+                         D_DECL(const int& dlo0,const int& dlo1,const int& dlo2),
+                         D_DECL(const int& dhi0,const int& dhi1,const int& dhi2),
+                         const int* lo, const int* hi, const int* nvar,
+                         const int* domain_lo, const int* domain_hi,
+                         const Real* dx, const Real* xlo,
+                         const Real* prob_lo, const Real* time,
+                         const int* level) const
+{
+    BL_ASSERT(lmef);
+
+    lmef(tag,D_DECL(tlo0,tlo1,tlo2),D_DECL(thi0,thi1,thi2),tagval,clearval,
+         data,D_DECL(dlo0,dlo1,dlo2),D_DECL(dhi0,dhi1,dhi2),
+         lo, hi, nvar,domain_lo,domain_hi,dx,xlo,prob_lo,time,
+         level,&value);
+}
+
 void
 PeleLM::center_to_edge_fancy (const FArrayBox& cfab,
                               FArrayBox&       efab,
@@ -2374,10 +2407,6 @@ PeleLM::sum_integrated_quantities ()
 
   if (getChemSolve().index(productName) >= 0)
   {
-    int MyProc  = ParallelDescriptor::MyProc();
-    int step    = parent->levelSteps(0);
-    int restart = 0;
-
     Real productmass = 0.0;
     std::string product = "rho.Y(" + productName + ")";
     for (int lev = 0; lev <= finest_level; lev++) {
@@ -3877,7 +3906,6 @@ PeleLM::compute_rhoRT (const MultiFab& S,
 
   const Real strt_time = ParallelDescriptor::second();
 
-  const BoxArray& sgrids = S.boxArray();
   int nCompY = last_spec - first_spec + 1;
 
 #ifdef _OPENMP
@@ -5191,7 +5219,6 @@ PeleLM::compute_scalar_advection_fluxes_and_divergence (const MultiFab& Force,
   const Real  strt_time = ParallelDescriptor::second();
   const Real* dx        = geom.CellSize();
   const Real  prev_time = state[State_Type].prevTime();  
-  const int nState = desc_lst[State_Type].nComp();
 
   MultiFab dummy(grids,dmap,1,0,MFInfo().SetAlloc(false));
   
@@ -5225,7 +5252,6 @@ PeleLM::compute_scalar_advection_fluxes_and_divergence (const MultiFab& Force,
   for (MFIter S_mfi(Smf,true); S_mfi.isValid(); ++S_mfi)
   {
     const Box& bx = S_mfi.tilebox();
-    const FArrayBox& S = Smf[S_mfi];
     const FArrayBox& divu = DivU[S_mfi];
     const FArrayBox& force = Force[S_mfi];
 
@@ -5348,7 +5374,6 @@ PeleLM::mac_sync ()
   const Real tnp1       = state[State_Type].curTime();
   const Real prev_pres_time = state[Press_Type].prevTime();
   const Real dt             = parent->dtLevel(level);
-  MultiFab&  rhonph       = get_rho_half_time();
   //
   // DeltaSsync Will hold q^{n+1,p} * (delta rho)^sync for conserved quantities
   // as defined before Eq (18) in DayBell:2000.  Note that in the paper, 
@@ -7849,3 +7874,63 @@ PeleLM::derive (const std::string& name,
   }
 }
 
+void
+PeleLM::errorEst (TagBoxArray& tags,
+                  int         clearval,
+                  int         tagval,
+                  Real        time,
+                  int         n_error_buf, 
+                  int         ngrow)
+{
+  BL_PROFILE("PorousMedia::errorEst()");
+  const int*  domain_lo = geom.Domain().loVect();
+  const int*  domain_hi = geom.Domain().hiVect();
+  const Real* dx        = geom.CellSize();
+  const Real* prob_lo   = geom.ProbLo();
+
+  for (int j = 0; j < err_list.size(); j++)
+  {
+    const ErrorRec::ErrorFunc& efunc = err_list[j].errFunc();
+    const LM_Error_Value* lmfunc = dynamic_cast<const LM_Error_Value*>(&efunc);
+    auto mf = derive(err_list[j].name(), time, err_list[j].nGrow());
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+    for (MFIter mfi(*mf,true); mfi.isValid(); ++mfi)
+    {
+      const Box&  vbx     = mfi.tilebox();
+      RealBox     gridloc = RealBox(vbx,geom.CellSize(),geom.ProbLo());
+      Vector<int> itags   = tags[mfi].tags();
+      int*        tptr    = itags.dataPtr();
+      const int*  tlo     = tags[mfi].box().loVect();
+      const int*  thi     = tags[mfi].box().hiVect();
+      const int*  lo      = vbx.loVect();
+      const int*  hi      = vbx.hiVect();
+      const Real* xlo     = gridloc.lo();
+      FArrayBox&  fab     = (*mf)[mfi];
+      Real*       dat     = fab.dataPtr();
+      const int*  dlo     = fab.box().loVect();
+      const int*  dhi     = fab.box().hiVect();
+      const int   ncomp   = fab.nComp();
+      
+      if (lmfunc==0) 
+      {
+        err_list[j].errFunc()(tptr, ARLIM(tlo), ARLIM(thi), &tagval,
+                              &clearval, dat, ARLIM(dlo), ARLIM(dhi),
+                              lo,hi, &ncomp, domain_lo, domain_hi,
+                              dx, xlo, prob_lo, &time, &level);
+      }
+      else
+      {
+        lmfunc->tagCells(tptr,ARLIM(tlo),ARLIM(thi),
+                         &tagval, &clearval, dat, ARLIM(dlo), ARLIM(dhi),
+                         lo,hi, &ncomp, domain_lo, domain_hi,
+                         dx, xlo, prob_lo, &time, &level);
+      }
+                      
+      tags[mfi].tags(itags);
+
+    }
+  }
+}

--- a/Source/PeleLM_2d.F90
+++ b/Source/PeleLM_2d.F90
@@ -32,7 +32,8 @@ module PeleLM_2d
              est_divu_dt, check_divu_dt, dqrad_fill, divu_fill, &
              dsdt_fill, ydot_fill, rhoYdot_fill, fab_minmax, repair_flux, &
              incrwext_flx_div, flux_div, compute_ugradp, conservative_T_floor, &
-             htdd_relax, part_cnt_err, mcurve, smooth, grad_wbar, recomp_update
+             part_cnt_err, mcurve, smooth, grad_wbar, recomp_update, &
+             valgt_error, vallt_error, diffgt_error
 
 contains
 
@@ -223,11 +224,10 @@ contains
 
     REAL_T, allocatable :: H(:,:,:)
 
-    integer i, j, d, n, elo, ehi
+    integer i, j, d, n
     integer lob(SDIM), hib(SDIM)
     REAL_T AxDxInv_lo, AxDxInv_hi, dxInv
     REAL_T AyDyInv_lo, AyDyInv_hi, dyInv
-    REAL_T FiHi
     logical fix_xlo, fix_xhi, fix_ylo, fix_yhi
 
     REAL_T, allocatable :: rhoInv(:,:)
@@ -1905,129 +1905,6 @@ contains
 
   end function conservative_T_floor
 
-!-----------------------------------------
-
-  subroutine htdd_relax(lo, hi, S, DIMS(S), yc, Tc, hc, rc, &
-                  L, DIMS(L), a, DIMS(a), R, DIMS(R), thetaDt, fac, maxRes, maxCor, &
-                  for_T0_H1, res_only, mult) &
-                  bind(C, name="htdd_relax")
-
-    implicit none
-
-#include <cdwrk.H>      
-
-    integer lo(SDIM), hi(SDIM), yc, Tc, hc, rc
-    integer DIMDEC(S)
-    integer DIMDEC(L)
-    integer DIMDEC(a)
-    integer DIMDEC(R)
-    REAL_T S(DIMV(s),0:*)
-    REAL_T L(DIMV(L),0:*)
-    REAL_T a(DIMV(a),0:*)
-    REAL_T R(DIMV(R),0:*)
-    REAL_T thetaDt, fac(0:*), maxRes(0:*), maxCor(0:*)
-    integer for_T0_H1, res_only
-    REAL_T mult, cor
-    integer i, j, n
-
-#ifdef HT_SKIP_NITROGEN
-    REAL_T, allocatable :: tfab(:,:)
-#endif
-
-!
-!     Helper function to compute:
-!     (a) dR = Rhs + (rho.phi - theta.dt.Lphi)
-!     (b) Res = Rhs - A(S) = Rhs - (rho.phi - theta.dt.Lphi) for RhoH
-!         or  Res = Rhs - (phi - theta.dt.Lphi) for Temp
-!               and then relax: phi = phi + Res/alpha
-!     -- note that if for Temp both Lphi and alpha have been scaled by (1/rho.Cp)^nph
-!     
-!     NOTE: Assumes maxRes and maxCor have been initialized properly
-!
-    do n=0,Nspec-1
-      do j=lo(2),hi(2)
-        do i=lo(1),hi(1)
-          L(i,j,n) = R(i,j,n) + mult*(S(i,j,rc)*S(i,j,yc+n) - thetaDt*L(i,j,n))
-           maxRes(n) = MAX(maxRes(n),ABS(L(i,j,n)))
-         enddo
-      enddo
-    enddo
-#ifdef HT_SKIP_NITROGEN
-    do j=lo(2),hi(2)
-      do i=lo(1),hi(1)
-        L(i,j,Nspec-1) = 0.d0
-      enddo
-    enddo
-    maxRes(Nspec-1) = 0.d0
-#endif
-
-    if (for_T0_H1.eq.0) then
-      do j=lo(2),hi(2)
-        do i=lo(1),hi(1)
-          L(i,j,Nspec) = R(i,j,Nspec) + mult*(S(i,j,Tc) - thetaDt*L(i,j,Nspec))
-          maxRes(Nspec) = MAX(maxRes(Nspec),ABS(L(i,j,Nspec)))
-        enddo
-      enddo
-    else
-      do j=lo(2),hi(2)
-        do i=lo(1),hi(1)
-          L(i,j,Nspec) = R(i,j,Nspec) + mult*(S(i,j,rc)*S(i,j,Hc) - thetaDt*L(i,j,Nspec))
-          maxRes(Nspec) = MAX(maxRes(Nspec),ABS(L(i,j,Nspec)))
-        enddo
-      enddo
-    endif
-
-    if (res_only.ne.1) then
-      do n=0,Nspec-1
-        do j=lo(2),hi(2)
-          do i=lo(1),hi(1)
-            cor = fac(n) * L(i,j,n) / (S(i,j,rc) - thetaDt*a(i,j,n))
-            maxCor(n) = MAX(maxCor(n),ABS(cor))
-            S(i,j,yc+n) = S(i,j,yc+n)  +  cor
-          enddo
-        enddo
-      enddo
-
-#ifdef HT_SKIP_NITROGEN
-      allocate(tfab(lo(1):hi(1),lo(2):hi(2)))
-      tfab = 0.0d0
-      do n=0,Nspec-2
-        do j=lo(2),hi(2)
-          do i=lo(1),hi(1)
-            tfab(i,j) = tfab(i,j) + S(i,j,yc+n)
-          enddo
-        enddo
-      end do
-      do j=lo(2),hi(2)
-        do i=lo(1),hi(1)
-          S(i,j,Nspec-1) = 1.d0 - tfab(i,j)
-        enddo
-      enddo
-      maxCor(Nspec-1) = 0.d0
-      deallocate(tfab)
-#endif
-
-      if (for_T0_H1.eq.0) then
-        do j=lo(2),hi(2)
-          do i=lo(1),hi(1)
-            cor = fac(Nspec) * L(i,j,Nspec) / (1.d0 - thetaDt*a(i,j,Nspec))
-            maxCor(Nspec) = MAX(maxCor(Nspec),ABS(cor))
-            S(i,j,Tc) = S(i,j,Tc)  +  cor
-          enddo
-        enddo
-      else
-        do j=lo(2),hi(2)
-          do i=lo(1),hi(1)
-            cor = fac(Nspec) * L(i,j,Nspec) / (S(i,j,rc) - thetaDt*a(i,j,Nspec))
-            maxCor(Nspec) = MAX(maxCor(Nspec),ABS(cor))
-            S(i,j,hc) = S(i,j,hc)  +  cor
-          enddo
-        enddo
-      endif
-    endif
-
-  end subroutine htdd_relax
-
 ! ::: -----------------------------------------------------------
 ! ::: This routine will tag high error cells based on whether or not
 ! ::: they contain any particles.
@@ -2264,5 +2141,107 @@ contains
     end do
 
   end subroutine recomp_update
+
+!-----------------------------------
+
+  subroutine valgt_error(tag,DIMS(tag),set,clear,&
+       adv,DIMS(adv),&
+       lo,hi,nvar,&
+       domlo,domhi,dx,xlo,&
+       problo,time,level,value) bind(C, name="valgt_error")
+
+    implicit none
+
+#include "probdata.H"
+      
+    integer   DIMDEC(tag)
+    integer   DIMDEC(adv)
+    integer   nvar, set, clear, level
+    integer   domlo(SDIM), domhi(SDIM)
+    integer   lo(SDIM), hi(SDIM)
+    integer   tag(DIMV(tag))
+    REAL_T    dx(SDIM), xlo(SDIM), problo(SDIM), time
+    REAL_T    adv(DIMV(adv),1)
+    REAL_T    value
+
+    integer   i, j
+
+    do i = lo(1), hi(1)
+       do j = lo(2), hi(2)
+          tag(i,j) = merge(set,tag(i,j),adv(i,j,1).gt.value)
+       end do
+    end do
+
+  end subroutine valgt_error
+
+  subroutine vallt_error(tag,DIMS(tag),set,clear,&
+       adv,DIMS(adv),&
+       lo,hi,nvar,&
+       domlo,domhi,dx,xlo,&
+       problo,time,level,value) bind(C, name="vallt_error")
+
+    implicit none
+
+#include "probdata.H"
+      
+    integer   DIMDEC(tag)
+    integer   DIMDEC(adv)
+    integer   nvar, set, clear, level
+    integer   domlo(SDIM), domhi(SDIM)
+    integer   lo(SDIM), hi(SDIM)
+    integer   tag(DIMV(tag))
+    REAL_T    dx(SDIM), xlo(SDIM), problo(SDIM), time
+    REAL_T    adv(DIMV(adv),1)
+    REAL_T    value
+
+    integer   i, j
+
+    do i = lo(1), hi(1)
+       do j = lo(2), hi(2)
+          tag(i,j) = merge(set,tag(i,j),adv(i,j,1).lt.value)
+       end do
+    end do
+
+  end subroutine vallt_error
+  
+
+  subroutine diffgt_error (tag,DIMS(tag),set,clear,&
+       adv,DIMS(adv),&
+       lo,hi,nvar,&
+       domlo,domhi,dx,xlo,&
+       problo,time,level,value) bind(C, name="diffgt_error")
+
+    implicit none
+
+#include "probdata.H"
+      
+    integer   DIMDEC(tag)
+    integer   DIMDEC(adv)
+    integer   nvar, set, clear, level
+    integer   domlo(SDIM), domhi(SDIM)
+    integer   lo(SDIM), hi(SDIM)
+    integer   tag(DIMV(tag))
+    REAL_T    dx(SDIM), xlo(SDIM), problo(SDIM), time
+    REAL_T    adv(DIMV(adv),1)
+    REAL_T    value
+    REAL_T    axp, axm, ayp, aym, aerr
+
+    integer   i, j
+
+
+    do i = lo(1), hi(1)
+       do j = lo(2), hi(2)
+          axp = ABS(adv(i+1,j,1) - adv(i,j,1))
+          axm = ABS(adv(i-1,j,1) - adv(i,j,1))
+          ayp = ABS(adv(i,j+1,1) - adv(i,j,1))
+          aym = ABS(adv(i,j-1,1) - adv(i,j,1))
+          aerr = MAX(axp,MAX(axm,MAX(ayp,aym)))
+
+          if (aerr.gt.value) then
+             tag(i,j) = set
+          endif
+       end do
+    end do
+  end subroutine diffgt_error
 
 end module PeleLM_2d

--- a/Source/PeleLM_3d.F90
+++ b/Source/PeleLM_3d.F90
@@ -32,7 +32,8 @@ module PeleLM_3d
              est_divu_dt, check_divu_dt, dqrad_fill, divu_fill, &
              dsdt_fill, ydot_fill, rhoYdot_fill, fab_minmax, repair_flux, &
              incrwext_flx_div, flux_div, compute_ugradp, conservative_T_floor, &
-             htdd_relax, part_cnt_err, mcurve, smooth, grad_wbar, recomp_update
+             part_cnt_err, mcurve, smooth, grad_wbar, recomp_update, &
+             valgt_error, vallt_error, diffgt_error
 
 contains
              
@@ -2399,146 +2400,6 @@ contains
 
 !-----------------------------------------
 
-  subroutine htdd_relax(lo, hi, S, DIMS(S), yc, Tc, hc, rc, &
-          L, DIMS(L), a, DIMS(a), R, DIMS(R), thetaDt, fac, maxRes, maxCor, &
-          for_T0_H1, res_only, mult) &
-          bind(C, name="htdd_relax")
-                   
-      implicit none
-      
-#include <cdwrk.H>
-
-      integer lo(SDIM), hi(SDIM), yc, Tc, hc, rc
-      integer DIMDEC(S)
-      integer DIMDEC(L)
-      integer DIMDEC(a)
-      integer DIMDEC(R)
-      REAL_T S(DIMV(s),0:*)
-      REAL_T L(DIMV(L),0:*)
-      REAL_T a(DIMV(a),0:*)
-      REAL_T R(DIMV(R),0:*)
-      REAL_T thetaDt, fac(0:*), maxRes(0:*), maxCor(0:*)
-      integer for_T0_H1, res_only
-      REAL_T mult, cor
-      integer i, j, k, n
-
-#ifdef HT_SKIP_NITROGEN
-      REAL_T, allocatable :: tfab(:,:,:)
-#endif
-
-!
-!     Helper function to compute:
-!     (a) dR = Rhs + (rho.phi - theta.dt.Lphi)
-!     (b) Res = Rhs - A(S) = Rhs - (rho.phi - theta.dt.Lphi) for RhoH
-!         or  Res = Rhs - (phi - theta.dt.Lphi) for Temp
-!               and then relax: phi = phi + Res/alpha
-!     -- note that if for Temp both Lphi and alpha have been scaled by (1/rho.Cp)^nph
-!     
-!     NOTE: Assumes maxRes and maxCor have been initialized properly
-!
-
-      do n=0,Nspec-1
-         do k=lo(3),hi(3)
-            do j=lo(2),hi(2)
-               do i=lo(1),hi(1)
-                  L(i,j,k,n) = R(i,j,k,n) + mult*(S(i,j,k,rc)*S(i,j,k,yc+n) - thetaDt*L(i,j,k,n))
-                  maxRes(n) = MAX(maxRes(n),ABS(L(i,j,k,n)))
-               enddo
-            enddo
-         enddo
-      enddo
-
-#ifdef HT_SKIP_NITROGEN
-      do k=lo(3),hi(3)
-         do j=lo(2),hi(2)
-            do i=lo(1),hi(1)
-               L(i,j,k,Nspec-1) = 0.d0
-            enddo
-         enddo
-      enddo
-      maxRes(Nspec-1) = 0.d0
-#endif
-
-      if (for_T0_H1.eq.0) then
-         do k=lo(3),hi(3)
-            do j=lo(2),hi(2)
-               do i=lo(1),hi(1)
-                  L(i,j,k,Nspec) = R(i,j,k,Nspec) + mult*(S(i,j,k,Tc) - thetaDt*L(i,j,k,Nspec))
-                  maxRes(Nspec) = MAX(maxRes(Nspec),ABS(L(i,j,k,Nspec)))
-               enddo
-            enddo
-         enddo
-      else
-         do k=lo(3),hi(3)
-            do j=lo(2),hi(2)
-               do i=lo(1),hi(1)
-                  L(i,j,k,Nspec) = R(i,j,k,Nspec) + mult*(S(i,j,k,rc)*S(i,j,k,hc) - thetaDt*L(i,j,k,Nspec))
-                  maxRes(Nspec) = MAX(maxRes(Nspec),ABS(L(i,j,k,Nspec)))
-               enddo
-            enddo
-         enddo
-      endif
-
-      if (res_only.ne.1) then
-         do n=0,Nspec-1
-            do k=lo(3),hi(3)
-               do j=lo(2),hi(2)
-                  do i=lo(1),hi(1)
-                     cor = fac(n) * L(i,j,k,n) / (S(i,j,k,rc) - thetaDt*a(i,j,k,n))
-                     maxCor(n) = MAX(maxCor(n),ABS(cor))
-                     S(i,j,k,yc+n) = S(i,j,k,yc+n)  +  cor
-                  enddo
-               enddo
-            enddo
-         enddo
-#ifdef HT_SKIP_NITROGEN
-         allocate(tfab(lo(1):hi(1),lo(2):hi(2),lo(3):hi(3)))
-         tfab = zero
-         do n=0,Nspec-2
-            do k=lo(3),hi(3)
-               do j=lo(2),hi(2)
-                  do i=lo(1),hi(1)
-                     tfab(i,j,k) = tfab(i,j,k) + S(i,j,k,yc+n)
-                  enddo
-               enddo
-            enddo
-         end do
-         do k=lo(3),hi(3)
-            do j=lo(2),hi(2)
-               do i=lo(1),hi(1)
-                  S(i,j,k,Nspec-1) = 1.d0 - tfab(i,j,k)
-               enddo
-            enddo
-         enddo
-         maxCor(Nspec-1) = 0.d0
-         deallocate(tfab)
-#endif
-
-         if (for_T0_H1.eq.0) then
-            do k=lo(3),hi(3)
-               do j=lo(2),hi(2)
-                  do i=lo(1),hi(1)
-                     cor = fac(Nspec) * L(i,j,k,Nspec) / (1.d0 - thetaDt*a(i,j,k,Nspec))
-                     maxCor(Nspec) = MAX(maxCor(Nspec),ABS(cor))
-                     S(i,j,k,Tc) = S(i,j,k,Tc)  +  cor
-                  enddo
-               enddo
-            enddo
-         else
-            do k=lo(3),hi(3)
-               do j=lo(2),hi(2)
-                  do i=lo(1),hi(1)
-                     cor = fac(Nspec) * L(i,j,k,Nspec) / (S(i,j,k,rc) - thetaDt*a(i,j,k,Nspec))
-                     maxCor(Nspec) = MAX(maxCor(Nspec),ABS(cor))
-                     S(i,j,k,hc) = S(i,j,k,hc)  +  cor
-                  enddo
-               enddo
-            enddo
-         endif
-      endif
-      
-  end subroutine htdd_relax
-
 ! ::: -----------------------------------------------------------
 ! ::: This routine will tag high error cells based on whether or not
 ! ::: they contain any particles.
@@ -2834,5 +2695,114 @@ contains
       end do
 
   end subroutine recomp_update
+
+!-----------------------------------
+
+  subroutine valgt_error(tag,DIMS(tag),set,clear,&
+       adv,DIMS(adv),&
+       lo,hi,nvar,&
+       domlo,domhi,dx,xlo,&
+       problo,time,level,value) bind(C, name="valgt_error")
+
+    implicit none
+
+#include "probdata.H"
+      
+    integer   DIMDEC(tag)
+    integer   DIMDEC(adv)
+    integer   nvar, set, clear, level
+    integer   domlo(SDIM), domhi(SDIM)
+    integer   lo(SDIM), hi(SDIM)
+    integer   tag(DIMV(tag))
+    REAL_T    dx(SDIM), xlo(SDIM), problo(SDIM), time
+    REAL_T    adv(DIMV(adv),1)
+    REAL_T    value
+
+    integer   i, j, k
+
+    do k = lo(3), hi(3)
+       do j = lo(2), hi(2)
+          do i = lo(1), hi(1)
+             tag(i,j,k) = merge(set,tag(i,j,k),adv(i,j,k,1).gt.value)
+          end do
+       end do
+    end do
+
+  end subroutine valgt_error
+
+  subroutine vallt_error(tag,DIMS(tag),set,clear,&
+       adv,DIMS(adv),&
+       lo,hi,nvar,&
+       domlo,domhi,dx,xlo,&
+       problo,time,level,value) bind(C, name="vallt_error")
+
+    implicit none
+
+#include "probdata.H"
+      
+    integer   DIMDEC(tag)
+    integer   DIMDEC(adv)
+    integer   nvar, set, clear, level
+    integer   domlo(SDIM), domhi(SDIM)
+    integer   lo(SDIM), hi(SDIM)
+    integer   tag(DIMV(tag))
+    REAL_T    dx(SDIM), xlo(SDIM), problo(SDIM), time
+    REAL_T    adv(DIMV(adv),1)
+    REAL_T    value
+
+    integer   i, j, k
+
+    do k = lo(3), hi(3)
+       do j = lo(2), hi(2)
+          do i = lo(1), hi(1)
+             tag(i,j,k) = merge(set,tag(i,j,k),adv(i,j,k,1).lt.value)
+          end do
+       end do
+    end do
+
+  end subroutine vallt_error
+  
+
+  subroutine diffgt_error (tag,DIMS(tag),set,clear,&
+       adv,DIMS(adv),&
+       lo,hi,nvar,&
+       domlo,domhi,dx,xlo,&
+       problo,time,level,value) bind(C, name="diffgt_error")
+
+    implicit none
+
+#include "probdata.H"
+      
+    integer   DIMDEC(tag)
+    integer   DIMDEC(adv)
+    integer   nvar, set, clear, level
+    integer   domlo(SDIM), domhi(SDIM)
+    integer   lo(SDIM), hi(SDIM)
+    integer   tag(DIMV(tag))
+    REAL_T    dx(SDIM), xlo(SDIM), problo(SDIM), time
+    REAL_T    adv(DIMV(adv),1)
+    REAL_T    value
+    REAL_T    axp, axm, ayp, aym, azp, azm, aerr
+
+    integer   i, j, k
+
+    do k = lo(3), hi(3)
+       do j = lo(2), hi(2)
+          do i = lo(1), hi(1)
+             axp = ABS(adv(i+1,j,k,1) - adv(i,j,k,1))
+             axm = ABS(adv(i-1,j,k,1) - adv(i,j,k,1))
+             ayp = ABS(adv(i,j+1,k,1) - adv(i,j,k,1))
+             aym = ABS(adv(i,j-1,k,1) - adv(i,j,k,1))
+             azp = ABS(adv(i,j,k+1,1) - adv(i,j,k,1))
+             azm = ABS(adv(i,j,k-1,1) - adv(i,j,k,1))
+             aerr = MAX(azp,MAX(azm,MAX(axp,MAX(axm,MAX(ayp,aym)))))
+
+             if (aerr.gt.value) then
+                tag(i,j,k) = set
+             endif
+          end do
+       end do
+    end do
+  end subroutine diffgt_error
 
 end module PeleLM_3d

--- a/Source/PeleLM_F.H
+++ b/Source/PeleLM_F.H
@@ -255,6 +255,33 @@ extern "C" {
                      const amrex::Real* delta, const int* dir,
                      const amrex::Real* mult, const amrex::Real* inc);
     
+  void valgt_error(int* tag, ARLIM_P(tlo), ARLIM_P(thi),
+                   const int* tagval, const int* clearval,
+                   const amrex::Real* data, ARLIM_P(data_lo), ARLIM_P(data_hi),
+                   const int* lo, const int* hi, const int* nvar,
+                   const int* domain_lo, const int* domain_hi,
+                   const amrex::Real* dx, const amrex::Real* xlo,
+                   const amrex::Real* prob_lo, const amrex::Real* time,
+                   const int* level, const amrex::Real* value);
+
+  void vallt_error(int* tag, ARLIM_P(tlo), ARLIM_P(thi),
+                   const int* tagval, const int* clearval,
+                   const amrex::Real* data, ARLIM_P(data_lo), ARLIM_P(data_hi),
+                   const int* lo, const int* hi, const int* nvar,
+                   const int* domain_lo, const int* domain_hi,
+                   const amrex::Real* dx, const amrex::Real* xlo,
+                   const amrex::Real* prob_lo, const amrex::Real* time,
+                   const int* level, const amrex::Real* value);
+
+  void diffgt_error(int* tag, ARLIM_P(tlo), ARLIM_P(thi),
+                    const int* tagval, const int* clearval,
+                    const amrex::Real* data, ARLIM_P(data_lo), ARLIM_P(data_hi),
+                    const int* lo, const int* hi, const int* nvar,
+                    const int* domain_lo, const int* domain_hi,
+                    const amrex::Real* dx, const amrex::Real* xlo,
+                    const amrex::Real* prob_lo, const amrex::Real* time,
+                    const int* level, const amrex::Real* value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/PeleLM_setup.cpp
+++ b/Source/PeleLM_setup.cpp
@@ -892,6 +892,45 @@ PeleLM::variableSetUp ()
     const std::string chname = "Y("+flameTracName+")";
     err_list.add(chname,nGrowErr,ErrorRec::Special,flame_tracer_error);
   }
+
+  //
+  // Dynamically generated error tagging functions
+  //
+  std::string amr_prefix = "amr";
+  ParmParse ppamr(amr_prefix);
+  Vector<std::string> refinement_indicators;
+  ppamr.queryarr("refinement_indicators",refinement_indicators,0,ppamr.countval("refinement_indicators"));
+  for (int i=0; i<refinement_indicators.size(); ++i)
+  {
+    std::string ref_prefix = amr_prefix + "." + refinement_indicators[i];
+
+    ParmParse ppr(ref_prefix);
+    Real min_time = 0; ppr.query("start_time",min_time);
+    Real max_time = -1; ppr.query("end_time",max_time);
+    int max_level = -1;  ppr.query("max_level",max_level);
+    
+    if (ppr.countval("value_greater")) {
+      Real value; ppr.get("value_greater",value);
+      std::string field; ppr.get("field_name",field);
+      err_list.add(field.c_str(),0,ErrorRec::Special,
+                   LM_Error_Value(valgt_error,value,min_time,max_time,max_level));
+    }
+    else if (ppr.countval("value_less")) {
+      Real value; ppr.get("value_less",value);
+      std::string field; ppr.get("field_name",field);
+      err_list.add(field.c_str(),0,ErrorRec::Special,
+                   LM_Error_Value(vallt_error,value,min_time,max_time,max_level));
+    }
+    else if (ppr.countval("adjacent_difference_greater")) {
+      Real value; ppr.get("adjacent_difference_greater",value);
+      std::string field; ppr.get("field_name",field);
+      err_list.add(field.c_str(),1,ErrorRec::Special,
+                   LM_Error_Value(diffgt_error,value,min_time,max_time,max_level));
+    }
+    else {
+      Abort(std::string("Unrecognized refinement indicator for " + refinement_indicators[i]).c_str());
+    }
+  }
 }
 
 class PLMBld


### PR DESCRIPTION
Have a look at the dynamic refinement criteria and the documentation for how to use.

At the moment, the new criteria work in addition to all those already in the code.  If this seems ok, we could remove all the redundant ones and their associated namelisted control parameters (e.g. max_trac_lev, temperr, etc) from all the Exec folders, and trim out  error functions that can easily be replaced using the generic ones.

However, maybe I forgot something, or maybe you have a suggestion for how this might look better?
