### PR TITLE
Add function to tag on box in physical coordinates

### DIFF
--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -34,6 +34,15 @@ extern "C"
                        const amrex::Real* dx, const amrex::Real* xlo,
                        const amrex::Real* prob_lo, const amrex::Real* time,
                        const int* level, const amrex::Real* value);
+
+  typedef void (*LMEF_BOX) (int* tag, ARLIM_P(tlo), ARLIM_P(thi),
+                            const int* tagval, const int* clearval,
+                            const amrex::Real* blo, const amrex::Real* bhi,
+                            const int* lo, const int* hi,
+                            const int* domain_lo, const int* domain_hi,
+                            const amrex::Real* dx, const amrex::Real* xlo,
+                            const amrex::Real* prob_lo, const amrex::Real* time,
+                            const int* level);
 }
 
 class LM_Error_Value
@@ -43,16 +52,22 @@ class LM_Error_Value
 public:
   LM_Error_Value()
     :
-    lmef(0), value(), min_time(), max_time(), max_level() {}
+    lmef(0), lmef_box(0), value(), min_time(), max_time(), max_level() {}
   
   LM_Error_Value (amrex::Real min_time, amrex::Real max_time, int max_level);
   
   LM_Error_Value (LMEF lmef, amrex::Real value, amrex::Real min_time,
                   amrex::Real max_time, int max_level);
   
+  LM_Error_Value (LMEF_BOX lmef_box, const amrex::RealBox& box, amrex::Real min_time,
+                  amrex::Real max_time, int max_level);
+  
   virtual ~LM_Error_Value () {}
   
   virtual amrex::ErrorRec::ErrorFunc* clone () const {
+    if (BoxTag()) {
+      return new LM_Error_Value(lmef_box,box,min_time,max_time,max_level);
+    }
     return new LM_Error_Value(lmef,value,min_time,max_time,max_level);
   }
   
@@ -64,14 +79,26 @@ public:
                 const amrex::Real* dx, const amrex::Real* xlo,
                 const amrex::Real* prob_lo, const amrex::Real* time,
                 const int* level) const;
+
+  void tagCells1(int* tag, ARLIM_P(tlo), ARLIM_P(thi),
+                 const int* tagval, const int* clearval,
+                 const int* lo, const int* hi,
+                 const int* domain_lo, const int* domain_hi,
+                 const amrex::Real* dx, const amrex::Real* xlo,
+                 const amrex::Real* prob_lo, const amrex::Real* time,
+                 const int* level) const;
+  
   int MaxLevel() const {return max_level;}
   amrex::Real MinTime() const {return min_time;}
   amrex::Real MaxTime() const {return max_time;}
   amrex::Real Value() const {return value;}
+  bool BoxTag() const {return lmef==0 && lmef_box!=0;}
   
 protected:
   LMEF lmef;
+  LMEF_BOX lmef_box;
   amrex::Real value, min_time, max_time;
+  amrex::RealBox box;
   int max_level;
 };
 

--- a/Source/PeleLM_F.H
+++ b/Source/PeleLM_F.H
@@ -376,6 +376,15 @@ extern "C" {
                     const amrex::Real* prob_lo, const amrex::Real* time,
                     const int* level, const amrex::Real* value);
   
+  void box_error(int* tag, ARLIM_P(tlo), ARLIM_P(thi),
+                 const int* tagval, const int* clearval,
+                 const amrex::Real* blo, const amrex::Real* bhi,
+                 const int* lo, const int* hi,
+                 const int* domain_lo, const int* domain_hi,
+                 const amrex::Real* dx, const amrex::Real* xlo,
+                 const amrex::Real* prob_lo, const amrex::Real* time,
+                 const int* level);
+  
   void set_prob_spec (const int& dm,
                       const amrex::Real* problo, const amrex::Real* probhi,
                       const int* bathID,  const int* fuelID,

--- a/Source/PeleLM_setup.cpp
+++ b/Source/PeleLM_setup.cpp
@@ -922,7 +922,7 @@ PeleLM::variableSetUp ()
     std::string ref_prefix = amr_prefix + "." + refinement_indicators[i];
 
     ParmParse ppr(ref_prefix);
-    Real min_time = 0; ppr.query("start_time",min_time);
+    Real min_time =  0; ppr.query("start_time",min_time);
     Real max_time = -1; ppr.query("end_time",max_time);
     int max_level = -1;  ppr.query("max_level",max_level);
     
@@ -950,8 +950,13 @@ PeleLM::variableSetUp ()
       err_list.add(field.c_str(),1,ErrorRec::Special,
                    LM_Error_Value(diffgt_error,value,min_time,max_time,max_level));
     }
-    else if (ppr.countval("adjacent_difference_less")) {
-      Abort(std::string("adjacent_difference_less refinement indicator not yet implemented, please find a PostDoc to do that"));
+    else if (ppr.countval("in_box_lo")) {
+      std::vector<Real> box_lo(BL_SPACEDIM), box_hi(BL_SPACEDIM);
+      ppr.getarr("in_box_lo",box_lo,0,box_lo.size());
+      ppr.getarr("in_box_hi",box_hi,0,box_hi.size());
+      RealBox realbox(&(box_lo[0]),&(box_hi[0]));
+      err_list.add("dummy",1,ErrorRec::Special,
+                   LM_Error_Value(box_error,realbox,min_time,max_time,max_level));
     }
     else {
       Abort(std::string("Unrecognized refinement indicator for " + refinement_indicators[i]).c_str());

--- a/Source/Src_2d/PeleLM_2d.F90
+++ b/Source/Src_2d/PeleLM_2d.F90
@@ -2916,6 +2916,37 @@ contains
     end do
   end subroutine diffgt_error
 
+  subroutine box_error (tag,DIMS(tag),set,clear,&
+       boxlo,boxhi,lo,hi,&
+       domlo,domhi,dx,xlo,&
+       problo,time,level) bind(C, name="box_error")
+
+    implicit none
+      
+    integer   DIMDEC(tag)
+    integer   set, clear, level
+    integer   domlo(dim), domhi(dim)
+    integer   lo(dim), hi(dim)
+    integer   tag(DIMV(tag))
+    REAL_T    boxlo(dim),boxhi(dim),dx(dim), xlo(dim), problo(dim), time
+
+    integer   i, j
+    REAL_T    x, y
+
+    do j = lo(2), hi(2)
+       y = (float(j)+.5)*dx(2)+problo(2)
+       if (y.ge.boxlo(2) .and. y.le.boxhi(2)) then
+          do i = lo(1), hi(1)
+             x = (float(i)+.5)*dx(1)+problo(1)
+             if (x.ge.boxlo(1) .and. x.le.boxhi(1)) then
+                tag(i,j) = set
+             endif
+          end do
+       endif
+    end do
+  end subroutine box_error
+
+
 !c ::: -----------------------------------------------------------
 !c
 !c     This routine averages the mac face velocities for makeforce at half time

--- a/Source/Src_3d/PeleLM_3d.F90
+++ b/Source/Src_3d/PeleLM_3d.F90
@@ -3379,6 +3379,42 @@ contains
     end do
   end subroutine diffgt_error
 
+  subroutine box_error (tag,DIMS(tag),set,clear,&
+       boxlo,boxhi,lo,hi,&
+       domlo,domhi,dx,xlo,&
+       problo,time,level) bind(C, name="box_error")
+
+    implicit none
+      
+    integer   DIMDEC(tag)
+    integer   set, clear, level
+    integer   domlo(dim), domhi(dim)
+    integer   lo(dim), hi(dim)
+    integer   tag(DIMV(tag))
+    REAL_T    boxlo(dim),boxhi(dim),dx(dim), xlo(dim), problo(dim), time
+
+    integer   i, j, k
+    REAL_T    x, y, z
+
+
+    do k = lo(3), hi(3)
+       z = (float(k)+.5)*dx(3)+problo(3)
+       if (z.ge.boxlo(3) .and. z.le.boxhi(3)) then
+          do j = lo(2), hi(2)
+             y = (float(j)+.5)*dx(2)+problo(2)
+             if (y.ge.boxlo(2) .and. y.le.boxhi(2)) then
+                do i = lo(1), hi(1)
+                   x = (float(i)+.5)*dx(1)+problo(1)
+                   if (x.ge.boxlo(1) .and. x.le.boxhi(1)) then
+                      tag(i,j) = set
+                   endif
+                end do
+             endif
+          end do
+       endif
+    end do
+  end subroutine box_error
+
 !c     
 !c     
 !c     ::: -----------------------------------------------------------


### PR DESCRIPTION
Also, add code to enforce max_level and time bounds on all refinement criteria.

To refine in the physical box ((0,01,0,2) (0.1,2.1,4.3)) add the following to inputs:

amr.refinement_indicators = RefineBox
amr.RefineBox.in_box_lo = 0 0.1 0.2
amr.Refinebox.in_box_hi = 0.1 2.1 4.3
