### PR TITLE
Dercpmix

### DIFF
--- a/Source/PeleLM_setup.cpp
+++ b/Source/PeleLM_setup.cpp
@@ -774,6 +774,14 @@ PeleLM::variableSetUp ()
   derive_lst.addComponent("molweight",desc_lst,State_Type,first_spec,nspecies);
   
   //
+  // Mixture heat capacity
+  //
+  derive_lst.add("cpmix",IndexType::TheCellType(),1,dercpmix,the_same_box);
+  derive_lst.addComponent("cpmix",desc_lst,State_Type,Density,1);
+  derive_lst.addComponent("cpmix",desc_lst,State_Type,Temp,1);
+  derive_lst.addComponent("cpmix",desc_lst,State_Type,first_spec,nspecies);
+  
+  //
   // Group Species Rho.Y (for ploting in plot file)
   //
   Vector<std::string> var_names_rhoY(nspecies);

--- a/Source/Prob_F.H
+++ b/Source/Prob_F.H
@@ -108,6 +108,14 @@
                         const amrex::Real* time, const amrex::Real* dt, const int* bcrec,
                         const int* level, const int* grid_no) ;
 
+     void dercpmix (BL_FORT_FAB_ARG_ANYD(der),const int* nvar,
+                    const BL_FORT_FAB_ARG_ANYD(data),const int* ncomp,
+                    const int* lo, const int* hi,
+                    const int* domain_lo, const int* domain_hi,
+                    const amrex::Real* delta, const amrex::Real* xlo,
+                    const amrex::Real* time, const amrex::Real* dt, const int* bcrec,
+                    const int* level, const int* grid_no) ;
+
      void dermixanddiss (BL_FORT_FAB_ARG_ANYD(der),const int* nvar,
                          const BL_FORT_FAB_ARG_ANYD(data),const int* ncomp,
                          const int* lo, const int* hi,

--- a/Source/Src_nd/Derive_PLM_nd.F90
+++ b/Source/Src_nd/Derive_PLM_nd.F90
@@ -1590,10 +1590,7 @@ contains
       T   = 2
       fS  = 3
 
-      call CKWT(invmwt)
-      do n=1,nspecies
-         invmwt(n) = one / invmwt(n)
-      end do
+      call get_imw(invmwt)
 
       do k=lo(3),hi(3)
          do j=lo(2),hi(2)

--- a/Source/Src_nd/Derive_PLM_nd.F90
+++ b/Source/Src_nd/Derive_PLM_nd.F90
@@ -1575,8 +1575,8 @@ contains
       integer, intent(in) :: level, grid_no
 
 !  Local
-      REAL_T, dimension(nspecies) :: Yt, D
-      REAL_T, dimension(1)        :: rho_dummy, MU, XI, LAM
+      REAL_T, dimension(nspecies) :: Yt, D, invmwt
+      REAL_T, dimension(1)        :: rho_dummy, MU, XI, LAM, Wavg
       REAL_T                      :: rhoinv
       integer :: fS, rho, T
       integer :: lo_chem(3), hi_chem(3)
@@ -1590,6 +1590,11 @@ contains
       T   = 2
       fS  = 3
 
+      call CKWT(invmwt)
+      do n=1,nspecies
+         invmwt(n) = one / invmwt(n)
+      end do
+
       do k=lo(3),hi(3)
          do j=lo(2),hi(2)
             do i=lo(1),hi(1)
@@ -1598,6 +1603,8 @@ contains
                   Yt(n) = dat(i,j,k,fS+n-1)*rhoinv
                enddo
                rho_dummy(1) = dat(i,j,k,rho) * 1.d-3
+
+               call CKMMWY(Yt,Wavg(1))
 
                CALL get_transport_coeffs(lo_chem, hi_chem, &
                                          Yt,           lo_chem,hi_chem,  &
@@ -1609,7 +1616,7 @@ contains
                                          LAM(1),       lo_chem,hi_chem)
 
                do n = 1,nspecies
-                  e(i,j,k,n) = D(n) * 0.1d0
+                  e(i,j,k,n) = Wavg(1) * invmwt(n) * D(n) * 0.1d0
                enddo
 
                e(i,j,k,nspecies+1) = LAM(1) * 1.0d-05

--- a/Source/Src_nd/Derive_PLM_nd.F90
+++ b/Source/Src_nd/Derive_PLM_nd.F90
@@ -1667,6 +1667,53 @@ contains
    end subroutine dermolweight
 
 !=========================================================
+!  Compute the mixture mean heat capacity at cst pressure
+!=========================================================
+
+   subroutine dercpmix (e,   e_lo, e_hi, nv, &
+                        dat, d_lo, d_hi, ncomp, &
+                        lo, hi, domlo, domhi, delta, xlo, time, dt, bc, &
+                        level, grid_no) &
+                        bind(C, name="dercpmix")
+
+      implicit none
+
+! In/Out
+      integer, intent(in) :: lo(3), hi(3)
+      integer, intent(in) :: e_lo(3), e_hi(3), nv
+      integer, intent(in) :: d_lo(3), d_hi(3), ncomp
+      integer, intent(in) :: domlo(3), domhi(3)
+      integer, intent(in) :: bc(3,2,ncomp)
+      REAL_T, intent(in)  :: delta(3), xlo(3), time, dt
+      REAL_T, intent(out),dimension(e_lo(1):e_hi(1),e_lo(2):e_hi(2),e_lo(3):e_hi(3),nv) :: e
+      REAL_T, intent(in), dimension(d_lo(1):d_hi(1),d_lo(2):d_hi(2),d_lo(3):d_hi(3),ncomp) :: dat
+      integer, intent(in) :: level, grid_no
+
+! Local
+      REAL_T, dimension(nspecies) :: Yt
+      integer :: fS,rho, T
+
+      integer :: i, j, k, n
+
+      rho = 1
+      T   = 2
+      fS  = 3
+
+      do k=lo(3),hi(3)
+         do j=lo(2),hi(2)
+            do i=lo(1),hi(1)
+               do n = 1,nspecies
+                  Yt(n) = dat(i,j,k,fS+n-1)/dat(i,j,k,rho)
+               enddo
+               CALL CKCPBS(dat(i,j,k,T),Yt,e(i,j,k,1))
+               e(i,j,k,1) = e(i,j,k,1) * 1.0d-4 ! CGS -> MKS
+            enddo
+         enddo
+      enddo
+
+   end subroutine dercpmix
+
+!=========================================================
 !  Init Bilger's element based mixture fraction
 !=========================================================
 


### PR DESCRIPTION
Add the cpmix in the derived function. Now you can compute the Lewis number in postproc. Also fix a bug in the cc_transport_coeffs.