### PR TITLE
[feature_clean_mixtfrac] Clean the mixture fraction computation in the

### DIFF
--- a/Exec/RegTests/FlameSheet/Prob_nd.F90
+++ b/Exec/RegTests/FlameSheet/Prob_nd.F90
@@ -53,6 +53,7 @@ contains
                                pseudo_gravity
       use probdata_module, only : standoff, pertmag, rho_bc, Y_bc
       use probdata_module, only : flame_dir
+      use derive_PLM_nd  , only : init_mixture_fraction
 
 
       implicit none
@@ -64,9 +65,9 @@ contains
 
       integer i,istemp
       REAL_T area
+      character(len=256) :: mixfrac_fueltank, mixfrac_oxitank
 
-      namelist /fortin/ V_in, &
-                        standoff, pertmag
+      namelist /fortin/ V_in, standoff, pertmag, mixfrac_fueltank, mixfrac_oxitank
       namelist /heattransin/ pamb
 
       namelist /control/ tau_control, sest, cfix, changeMax_control, h_control, &
@@ -125,6 +126,8 @@ contains
       pseudo_gravity = 0
       istemp = 0
       navg_pnts = 10
+      mixfrac_fueltank = ""
+      mixfrac_oxitank = ""
 
       read(untin,fortin)
 
@@ -138,6 +141,12 @@ contains
 
 !     Set up boundary functions
       call setupbc()
+
+!     Set mixture fraction data if asked
+      if ( ( LEN_TRIM(TRIM(mixfrac_fueltank)) /= 0 ) .and. &
+           ( LEN_TRIM(TRIM(mixfrac_oxitank)) /= 0 ) ) then
+               call init_mixture_fraction(mixfrac_fueltank, mixfrac_oxitank)
+      end if
 
       area = 1.d0
       do i=1,dim

--- a/Exec/RegTests/FlameSheet/inputs.2d-regt
+++ b/Exec/RegTests/FlameSheet/inputs.2d-regt
@@ -14,7 +14,7 @@ peleLM.hi_bc = Interior  Outflow
 
 #----------------------------TOP LEVEL INPUTS----------------------
 max_step  =  10000
-max_step  =  20
+max_step  =  10
 stop_time = 4.00
 
 #-------------------------AMR INPUTS----------------------------
@@ -37,7 +37,7 @@ amr.check_int       = 5       # number of timesteps between checkpoints
 
 amr.plot_file       = plt
 amr.plot_int        = 500
-amr.derive_plot_vars=rhoRT mag_vort avg_pressure gradpx gradpy diveru mass_fractions molweight
+amr.derive_plot_vars=rhoRT mag_vort avg_pressure gradpx gradpy diveru mass_fractions molweight mixfrac
 
 amr.grid_log        = grdlog  # name of grid logging file
 amr.max_grid_size   = 64

--- a/Exec/RegTests/FlameSheet/probin.3d.test
+++ b/Exec/RegTests/FlameSheet/probin.3d.test
@@ -1,8 +1,9 @@
  &fortin
-
   V_in = .2280410684149
   standoff = -.022
   pertmag = 0.0004
+  mixfrac_fueltank = "CH4:1.0"
+  mixfrac_oxitank  = "O2:0.233 N2:0.767"
  /
  &heattransin
   pamb = 101325.

--- a/Source/PeleLM_F.F90
+++ b/Source/PeleLM_F.F90
@@ -27,7 +27,8 @@ module PeleLM_F
             set_ht_adim_common, get_pamb, &
             set_common, active_control, &
             pphys_calc_src_sdc, pphys_getP1atm_MKS, &
-            pphys_get_spec_name2, pphys_TfromHYpt, set_prob_spec
+            pphys_get_spec_name2, pphys_TfromHYpt, set_prob_spec, &
+            parse_composition
 
 contains
 
@@ -165,6 +166,54 @@ end subroutine plm_extern_init
     pphys_getckspecname = str_len - 1
  
   end function pphys_getckspecname
+
+  subroutine parse_composition(compo_string, compo_vec)
+  
+    use network, only : nspecies, spec_names
+    use amrex_error_module, only : amrex_abort
+
+    implicit none
+
+    character(len=256), intent(in) :: compo_string
+    character(len=256) :: species_name
+    character(len=256) :: species_compo_s
+    double precision   :: species_compo_d
+    character(len=256) :: compo_string_trim
+    double precision, dimension(nspecies) :: compo_vec
+    integer i
+    
+    compo_vec(:) = 0.0d0
+
+    compo_string_trim = TRIM(ADJUSTL(compo_string))
+
+    do while ( LEN_TRIM(TRIM(compo_string_trim)) /= 0 ) 
+        ! Get species name
+        i = INDEX(compo_string_trim, ":")
+        species_name = compo_string_trim(1:i-1)
+        compo_string_trim = compo_string_trim(i+1:256)
+        ! Get compo for that name
+        i = INDEX(compo_string_trim, " ")
+        species_compo_s = compo_string_trim(1:i-1)
+        READ(species_compo_s,*) species_compo_d
+        compo_string_trim = compo_string_trim(i+1:256)
+        print *, 'NAME, COMPO ', TRIM(species_name), " ", TRIM(species_compo_s)
+        do i = 1, nspecies
+            if (TRIM(species_name) == spec_names(i)) then
+                compo_vec(i) = species_compo_d
+                exit
+            end if
+            if (i == nspecies) then
+                call amrex_abort('wrong string composition, species do not exist')
+            end if
+        end do
+    end do
+
+    ! Normalize to get mass fractions
+    compo_vec(:) = compo_vec(:) / SUM(compo_vec(:))
+
+    !print *, 'Composition vector is ', compo_vec(:)
+
+  end subroutine parse_composition
   
   function pphys_getRuniversal() bind(C, name="pphys_getRuniversal") result(RUNIV)
 


### PR DESCRIPTION
sources and add an exemple of its use in FlameSheet (note that it
entails modifying the probin and the Prob_nd.F90 + the inputs.2d-regt if
mixfrac is required in the plot file)
Basically, the problem was that the fuel tank and oxi tank were not
generalized (hard coded).

I don't know who put this feature (mixtrac) in the code originally (git blame gives me nothing), might be good to see if those guys are OK with what I've modified.