### PR TITLE
Anne/feature tolerances

### DIFF
--- a/Exec/RegTests/FlameSheet/GNUmakefile
+++ b/Exec/RegTests/FlameSheet/GNUmakefile
@@ -24,9 +24,18 @@ DO_2S_CONVERGENCE=FALSE
 
 #######################
 USE_SUNDIALS_PP = FALSE
-
-USE_KLU_PP = FALSE
-
+ifeq ($(USE_SUNDIALS_PP), TRUE)
+  # provide location of sundials lib if needed
+  #SUNDIALS_LIB_DIR=$(PELE_PHYSICS_HOME)/ThirdParty/sundials/instdir/lib/
+  # use KLU sparse features -- only useful if CVODE is used on CPU
+  USE_KLU_PP = TRUE
+  ifeq ($(USE_KLU_PP), TRUE)
+    # provide location of KLU lib if needed
+    #SUITESPARSE_DIR=$(PELE_PHYSICS_HOME)/ThirdParty/SuiteSparse/
+  endif
+  # Activates GPU version
+  USE_CUDA_SUNDIALS_PP = FALSE
+endif
 #######################
 
 # Enable ht.velocity_plotfile option

--- a/Exec/RegTests/FlameSheet/inputs.2d-regt
+++ b/Exec/RegTests/FlameSheet/inputs.2d-regt
@@ -105,9 +105,9 @@ ns.zeroBndryVisc=1
 ns.num_divu_iters =3
 
 # ------------------  INPUTS TO CVODE CHEMISTRY ----------------------
-#peleLM.use_typ_vals      = 0
+#peleLM.use_typ_vals_chem = 1
 #peleLM.relative_tol_chem = 1.0e-8
-#peleLM.absolute_tol_chem = 1.0e-8
+#peleLM.absolute_tol_chem = 1.0e-6
 cvode.solve_type = 1
 ode.analytical_jacobian = 0
 

--- a/Exec/RegTests/FlameSheet/inputs.2d-regt
+++ b/Exec/RegTests/FlameSheet/inputs.2d-regt
@@ -104,6 +104,12 @@ ns.do_fillPatchUMAC=1
 ns.zeroBndryVisc=1
 ns.num_divu_iters =3
 
+# ------------------  INPUTS TO CVODE CHEMISTRY ----------------------
+#peleLM.use_typ_vals      = 0
+#peleLM.relative_tol_chem = 1.0e-8
+#peleLM.absolute_tol_chem = 1.0e-8
+cvode.solve_type = 1
+ode.analytical_jacobian = 0
 
 # ------------------  INPUTS TO GODUNOV CLASS ----------------------
 godunov.slope_order = 4

--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -717,8 +717,10 @@ private:
   
   static bool         flag_active_control;
 
-  static int  cvode_iE;
-  static int  cvode_ncells;
+  static int  ncells_chem;
+  static bool use_typ_vals; 
+  static amrex::Real relative_tol_chem;
+  static amrex::Real absolute_tol_chem;
 
   static int nGrowAdvForcing;
 

--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -718,7 +718,7 @@ private:
   static bool         flag_active_control;
 
   static int  ncells_chem;
-  static bool use_typ_vals; 
+  static bool use_typ_vals_chem; 
   static amrex::Real relative_tol_chem;
   static amrex::Real absolute_tol_chem;
 

--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -1581,6 +1581,8 @@ PeleLM::restart (Amr&          papa,
 #ifdef _OPENMP
 #pragma omp parallel
 #endif  
+{
+#ifdef USE_SUNDIALS_PP
   if (use_typ_vals) {
       amrex::Print() << "Using typical values for the absolute tolerances of the ode solver.\n";
       Vector<Real> typical_values_chem;
@@ -1591,8 +1593,10 @@ PeleLM::restart (Amr&          papa,
       typical_values_chem[nspecies] = typical_values[Temp];
       SetTypValsODE(typical_values_chem);
   }
+#endif
   int reactor_type = 2;
   reactor_init(&reactor_type,&ncells_chem, relative_tol_chem, absolute_tol_chem);
+}
 
   if (closed_chamber) {
       std::string line;
@@ -2154,6 +2158,8 @@ MultiFab::Copy(S_new,P_new,0,RhoRT,1,1);
 #ifdef _OPENMP
 #pragma omp parallel
 #endif  
+{
+#ifdef USE_SUNDIALS_PP
   if (use_typ_vals) {
       amrex::Print() << "Using typical values for the absolute tolerances of the ode solver.\n";
       Vector<Real> typical_values_chem;
@@ -2166,6 +2172,7 @@ MultiFab::Copy(S_new,P_new,0,RhoRT,1,1);
   }
   int reactor_type = 2;
   reactor_init(&reactor_type,&ncells_chem, relative_tol_chem, absolute_tol_chem);
+}
 
   //
   // Initialize divU and dSdt.

--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -157,7 +157,7 @@ bool PeleLM::plot_reactions;
 bool PeleLM::plot_consumption;
 bool PeleLM::plot_heat_release;
 int  PeleLM::ncells_chem;
-bool PeleLM::use_typ_vals = 0;
+bool PeleLM::use_typ_vals_chem = 0;
 Real PeleLM::relative_tol_chem = 1.0e-10;
 Real PeleLM::absolute_tol_chem = 1.0e-10;
 static bool plot_rhoydot;
@@ -750,7 +750,7 @@ PeleLM::Initialize_specific ()
     pplm.query("deltaT_norm_max",deltaT_norm_max);
     pplm.query("deltaT_verbose",deltaT_verbose);
 
-    pplm.query("use_typ_vals",use_typ_vals);
+    pplm.query("use_typ_vals_chem",use_typ_vals_chem);
     pplm.query("relative_tol_chem",relative_tol_chem);
     pplm.query("absolute_tol_chem",absolute_tol_chem);
     
@@ -1701,7 +1701,7 @@ PeleLM::set_typical_values(bool is_restart)
       }
 
 #ifdef USE_SUNDIALS_PP
-    if (use_typ_vals) {
+    if (use_typ_vals_chem) {
       amrex::Print() << "Using typical values for the absolute tolerances of the ode solver\n";
 #ifdef _OPENMP
 #pragma omp parallel

--- a/Source/PeleLM_setup.cpp
+++ b/Source/PeleLM_setup.cpp
@@ -476,13 +476,8 @@ PeleLM::variableSetUp ()
   init_extern();
 
   /* PelePhysics */
-  amrex::Print() << " Initialization of network, reactor and transport \n";
+  amrex::Print() << " Initialization of network and transport \n";
   init_network();
-
-#ifdef _OPENMP
-#pragma omp parallel
-#endif  
-  reactor_init(&cvode_iE,&cvode_ncells);
 
   init_transport(use_tranlib);
 

--- a/Source/PeleLM_setup.cpp
+++ b/Source/PeleLM_setup.cpp
@@ -476,8 +476,18 @@ PeleLM::variableSetUp ()
   init_extern();
 
   /* PelePhysics */
-  amrex::Print() << " Initialization of network and transport \n";
+  amrex::Print() << " Initialization of network, reactor and transport \n";
   init_network();
+
+  int reactor_type = 2;
+#ifdef _OPENMP
+#pragma omp parallel
+#endif  
+{
+  SetTolFactODE(relative_tol_chem,absolute_tol_chem);
+  reactor_init(&reactor_type,&ncells_chem);
+}
+
 
   init_transport(use_tranlib);
 

--- a/Source/PeleLM_setup.cpp
+++ b/Source/PeleLM_setup.cpp
@@ -484,7 +484,9 @@ PeleLM::variableSetUp ()
 #pragma omp parallel
 #endif  
 {
+#ifdef USE_SUNDIALS_PP
   SetTolFactODE(relative_tol_chem,absolute_tol_chem);
+#endif
   reactor_init(&reactor_type,&ncells_chem);
 }
 


### PR DESCRIPTION
This PR goes with the PP PR Feature tolerances #68 of PP (https://github.com/AMReX-Combustion/PelePhysics/pull/68). Typical values were set in the code but never used. This PR closes the loop and feed these to the CVODE chemistry integration via a couple of custom PP functions.
The FlameSheet test case inputs.2d-regt and GNUmakefile have been adapted to be able to test this, although the default is still DVODE -and thus the RegTests should not be broken.