### PR TITLE
Updates to match IAMR Diffusion changes.

### DIFF
--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -3526,8 +3526,7 @@ PeleLM::differential_diffusion_update (MultiFab& Force,
 #endif
                                Tbc,curr_time);
 }
-// Dnew.setVal(0.) done in calling fn
-  //Dnew.setVal(0);
+  // Dnew.setVal(0.) done in calling fn
   flux_divergence(Dnew,DComp,SpecDiffusionFluxnp1,0,nspecies,-1);
   
   //
@@ -3893,17 +3892,13 @@ PeleLM::compute_enthalpy_fluxes (MultiFab* const*       flux,
   op.setLevelBC(0, &TT);
 
   // Creating alpha and beta coefficients.
-  MultiFab Alpha(grids,dmap,1,0,MFInfo(),Factory());
   Real      a               = 0;
   Real      b               = 1.;
-  Alpha.setVal(1.);
   op.setScalars(a, b);
-  op.setACoeffs(0, Alpha);
 
   // Here it is nspecies because lambda is stored after the last species (first starts at 0)
-  Array<MultiFab,BL_SPACEDIM> bcoeffs = Diffusion::computeBeta(beta, nspecies);
-  op.setBCoeffs(0, amrex::GetArrOfConstPtrs(bcoeffs));
-
+  Diffusion::setBeta(op,beta,nspecies);
+  
   D_TERM( flux[0]->setVal(0., nspecies+2, 1);,
           flux[1]->setVal(0., nspecies+2, 1);,
           flux[2]->setVal(0., nspecies+2, 1););
@@ -4070,7 +4065,8 @@ PeleLM::velocity_diffusion_update (Real dt)
     int rhsComp  = 0;
     int betaComp = 0;
     diffusion->diffuse_velocity(dt,be_cn_theta,get_rho_half_time(),rho_flag,
-                                delta_rhs,rhsComp,fb_betan.get(),fb_betanp1.get(),betaComp);
+                                delta_rhs,rhsComp,fb_betan.get(),viscn_cc,
+				fb_betanp1.get(),viscnp1_cc,betaComp);
 
     delete delta_rhs;
 
@@ -4193,7 +4189,10 @@ PeleLM::getViscTerms (MultiFab& visc_terms,
     }
 
     int viscComp = 0;
-    diffusion->getTensorViscTerms(visc_terms,time,vel_visc,viscComp);
+    const TimeLevel whichTime = which_time(State_Type,time);
+    BL_ASSERT(whichTime == AmrOldTime || whichTime == AmrNewTime);
+    auto vel_visc_cc = (whichTime == AmrOldTime ? viscn_cc : viscnp1_cc);
+    diffusion->getTensorViscTerms(visc_terms,time,vel_visc,vel_visc_cc,viscComp);
     showMF("velVT",visc_terms,"velVT_visc_terms_1",level);
   }
   else
@@ -4397,24 +4396,14 @@ PeleLM::compute_differential_diffusion_fluxes (const MultiFab& S,
 //	VisMF::Write(rh,"rh_cddf");
 
        Real* rhsscale = 0;
-       std::pair<Real,Real> scalars;
-       MultiFab Alpha;
        // above sets rho_flag = 2;
        // this is potentially dangerous if rho_flag==1, because rh is an undefined MF
        const MultiFab& rho = (rho_flag == 1) ? rh : S;
        const int Rho_comp = (rho_flag ==1) ? 0 : Density;
-
-       Diffusion::computeAlpha(Alpha, scalars, a, b, 
-                               rhsscale, alpha_in, alpha_in_comp+icomp,
-                               rho_flag, &rho, Rho_comp);
-       op.setScalars(scalars.first, scalars.second);
-       op.setACoeffs(0, Alpha);
+       op.setScalars(a,b);
     }
 
-    {
-      Array<MultiFab,BL_SPACEDIM> bcoeffs = Diffusion::computeBeta(beta, betaComp+icomp);
-      op.setBCoeffs(0, amrex::GetArrOfConstPtrs(bcoeffs));
-    }
+    Diffusion::setBeta(op,beta,betaComp+icomp);
 
     // No multiplication by dt here.
     Diffusion::computeExtensiveFluxes(mg, Soln, flux, fluxComp+icomp, 1, &geom, b);
@@ -5965,7 +5954,7 @@ PeleLM::advance_chemistry (MultiFab&       mf_old,
                            bool            use_stiff_solver)
 {
   BL_PROFILE("HT:::advance_chemistry()");
-
+  
   const Real strt_time = ParallelDescriptor::second();
 
   const bool do_avg_down_chem = avg_down_chem
@@ -6164,6 +6153,7 @@ PeleLM::advance_chemistry (MultiFab&       mf_old,
                 for (int sp=0;sp<nspecies; sp++){
                    tmp_vect[sp]       = rhoY(i,j,k,sp) * 1.e-3;
                    tmp_src_vect[sp]   = frcing(i,j,k,sp) * 1.e-3;
+
                 }
                 tmp_vect[nspecies]    = T(i,j,k);
                 tmp_vect_energy       = rhoH(i,j,k) * 10.0;
@@ -6193,16 +6183,19 @@ PeleLM::advance_chemistry (MultiFab&       mf_old,
                 for (int sp=0;sp<nspecies; sp++){
                    rhoY(i,j,k,sp)      = tmp_vect[sp] * 1.e+3;
                    if (isnan(rhoY(i,j,k,sp))) {
-                      amrex::Abort("NaNs !! ");
+                      amrex::Abort("NaNs in rhoY!! ");
+                   }
+                   if (isnan(frcing(i,j,k,sp))) {
+                      amrex::Abort("NaNs in forcing!! ");
                    }
                 }
                 T(i,j,k)  = tmp_vect[NUM_SPECIES];
                 if (isnan(T(i,j,k))) {
-                   amrex::Abort("NaNs !! ");
+                   amrex::Abort("NaNs in T!! ");
                 }
                 rhoH(i,j,k) = tmp_vect_energy * 1.e-01;
                 if (isnan(rhoH(i,j,k))) {
-                   amrex::Abort("NaNs !! ");
+                   amrex::Abort("NaNs in rhoH!! ");
                 }
              }
           }


### PR DESCRIPTION
1. Cell-centroid viscosity is now passed diffuse_tensor_velocity() for use in EB solve
2. Ensures bCoeffs are considered on centroids for EB

This is for use with IAMR PR #47. Note that this will change some answers for EB problems because bCoeffs were still on centers before.