### PR TITLE
Anne/dev gpu

### DIFF
--- a/Exec/RegTests/CoVo/Prob_nd.F90
+++ b/Exec/RegTests/CoVo/Prob_nd.F90
@@ -6,6 +6,7 @@
 
 #include <Prob_F.H>
 #include <PeleLM_F.H>
+#include <PPHYS_CONSTANTS.H>
 
 #include "mechanism.h"
 
@@ -44,7 +45,6 @@ contains
    subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
 
       use mod_Fvar_def, only : pamb
 
@@ -95,7 +95,7 @@ contains
       open(untin,file=probin(1:namlen),form='formatted',status='old')
       
 !     Set defaults
-      pamb = pphys_getP1atm_MKS()
+      pamb = PP_PA_MKS
 
       meanFlowDir = 1.0
       meanFlowMag = 1.0d0
@@ -164,7 +164,6 @@ contains
                         delta, xlo, xhi) &
                         bind(C, name="init_data")
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : Density, Temp, FirstSpec, RhoH, domnlo
 
@@ -246,7 +245,7 @@ contains
          end do
       end do
 
-      Patm = P_mean / pphys_getP1atm_MKS()
+      Patm = P_mean / PP_PA_MKS
 
       call pphys_RHOfromPTY(lo,hi, &
                             scal(:,:,:,Density),   s_lo, s_hi, &

--- a/Exec/RegTests/ControlledInflow/Prob_nd.F90
+++ b/Exec/RegTests/ControlledInflow/Prob_nd.F90
@@ -6,6 +6,7 @@
 
 #include <Prob_F.H>
 #include <PeleLM_F.H>
+#include <PPHYS_CONSTANTS.H>
 
 #include "mechanism.h"
 
@@ -44,7 +45,6 @@ contains
 
    subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use mod_Fvar_def, only : pamb, fuelID, domnhi, domnlo
       use mod_Fvar_def, only : ac_hist_file, cfix, changemax_control, &
                                coft_old, controlvelmax, corr, dv_control, &
@@ -102,7 +102,7 @@ contains
       open(untin,file=probin(1:namlen),form='formatted',status='old')
       
 !     Set defaults
-      pamb = pphys_getP1atm_MKS()
+      pamb = PP_PA_MKS
 
       zbase_control = 0.d0
 
@@ -162,7 +162,6 @@ contains
 
    subroutine setupbc()bind(C, name="setupbc")
 
-      use PeleLM_F, only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : pamb, domnlo, V_in
       use probdata_module, only : standoff, Y_bc, T_bc, u_bc, v_bc, w_bc, rho_bc, h_bc
@@ -176,7 +175,7 @@ contains
       data  b_lo(:) / 1, 1, 1 /
       data  b_hi(:) / 1, 1, 1 /
 
-      Patm = pamb / pphys_getP1atm_MKS()
+      Patm = pamb / PP_PA_MKS
 
       ! Take fuel mixture from pmf file
       loc = (domnlo(2)-standoff)*100.d0
@@ -263,7 +262,6 @@ contains
                         delta, xlo, xhi) &
                         bind(C, name="init_data")
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : Density, Temp, FirstSpec, RhoH, pamb
       use mod_Fvar_def, only : bathID, domnhi, domnlo
@@ -345,7 +343,7 @@ contains
          end do
       end do
 
-      Patm = pamb / pphys_getP1atm_MKS()
+      Patm = pamb / PP_PA_MKS
 
       call pphys_RHOfromPTY(lo,hi, &
                             scal(:,:,:,Density),   s_lo, s_hi, &

--- a/Exec/RegTests/ConvGaussian/Prob_nd.F90
+++ b/Exec/RegTests/ConvGaussian/Prob_nd.F90
@@ -6,6 +6,7 @@
 
 #include <Prob_F.H>
 #include <PeleLM_F.H>
+#include <PPHYS_CONSTANTS.H>
 #include "mechanism.h"
 
 module prob_nd_module
@@ -43,7 +44,6 @@ contains
    subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
 
       use mod_Fvar_def, only : pamb
 
@@ -94,7 +94,7 @@ contains
       open(untin,file=probin(1:namlen),form='formatted',status='old')
       
 !     Set defaults
-      pamb = pphys_getP1atm_MKS()
+      pamb = PP_PA_MKS
 
       meanFlowDir = 1.0
       meanFlowMag = 1.0d0
@@ -164,7 +164,6 @@ contains
                         delta, xlo, xhi) &
                         bind(C, name="init_data")
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : Density, Temp, FirstSpec, RhoH, domnlo
 
@@ -247,7 +246,7 @@ contains
          end do
       end do
 
-      Patm = P_mean / pphys_getP1atm_MKS()
+      Patm = P_mean / PP_PA_MKS
 
       call pphys_RHOfromPTY(lo,hi, &
                             scal(:,:,:,Density),   s_lo, s_hi, &

--- a/Exec/RegTests/DiffGaussian/Prob_nd.F90
+++ b/Exec/RegTests/DiffGaussian/Prob_nd.F90
@@ -7,6 +7,7 @@
 #include <Prob_F.H>
 #include <PeleLM_F.H>
 #include "mechanism.h"
+#include <PPHYS_CONSTANTS.H>
 
 module prob_nd_module
 
@@ -43,7 +44,6 @@ contains
    subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
 
       use mod_Fvar_def, only : pamb
 
@@ -95,7 +95,7 @@ contains
       open(untin,file=probin(1:namlen),form='formatted',status='old')
       
 !     Set defaults
-      pamb = pphys_getP1atm_MKS()
+      pamb = PP_PA_MKS
 
       meanFlowDir = 1.0
       meanFlowMag = 1.0d0
@@ -167,7 +167,6 @@ contains
                         delta, xlo, xhi) &
                         bind(C, name="init_data")
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : Density, Temp, FirstSpec, RhoH, domnlo
 
@@ -277,7 +276,7 @@ contains
          end do
       end do
 
-      Patm = P_mean / pphys_getP1atm_MKS()
+      Patm = P_mean / PP_PA_MKS
 
       call pphys_RHOfromPTY(lo,hi, &
                             scal(:,:,:,Density),   s_lo, s_hi, &

--- a/Exec/RegTests/DiffusionBox/Prob_nd.F90
+++ b/Exec/RegTests/DiffusionBox/Prob_nd.F90
@@ -8,6 +8,7 @@
 #include <PeleLM_F.H>
 
 #include "mechanism.h"
+#include <PPHYS_CONSTANTS.H>
 
 
 module prob_nd_module
@@ -44,7 +45,6 @@ contains
 
    subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
 
       use mod_Fvar_def, only : pamb, fuelID, domnhi, domnlo
 
@@ -104,7 +104,7 @@ contains
       open(untin,file=probin(1:namlen),form='formatted',status='old')
       
 !     Set defaults
-      pamb = pphys_getP1atm_MKS()
+      pamb = PP_PA_MKS
 
       zbase_control = 0.d0
 
@@ -165,7 +165,6 @@ contains
 
    subroutine setupbc() bind(C, name="setupbc")
 
-      use PeleLM_F, only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : pamb, domnlo, V_in
       use probdata_module, only : standoff, Y_bc, T_bc, u_bc, v_bc, w_bc, rho_bc, h_bc
@@ -179,7 +178,7 @@ contains
       data  b_lo(:) / 1, 1, 1 /
       data  b_hi(:) / 1, 1, 1 /
 
-      Patm = pamb / pphys_getP1atm_MKS()
+      Patm = pamb / PP_PA_MKS
 
 !     Take fuel mixture from pmf file
 #if ( AMREX_SPACEDIM == 2 )
@@ -270,7 +269,6 @@ contains
                         delta, xlo, xhi) &
                         bind(C, name="init_data")
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : Density, Temp, FirstSpec, RhoH, pamb
       use mod_Fvar_def, only : domnhi, domnlo
@@ -364,7 +362,7 @@ contains
          end do
       end do
          
-      Patm = pamb / pphys_getP1atm_MKS()
+      Patm = pamb / PP_PA_MKS
 
       call pphys_RHOfromPTY(lo,hi, &
                             scal(:,:,:,Density),   s_lo, s_hi, &

--- a/Exec/RegTests/EB_Convection_Wave_Species/Prob_nd.F90
+++ b/Exec/RegTests/EB_Convection_Wave_Species/Prob_nd.F90
@@ -8,6 +8,7 @@
 #include <PeleLM_F.H>
 
 #include "mechanism.h"
+#include <PPHYS_CONSTANTS.H>
 
 module prob_nd_module
 
@@ -43,7 +44,6 @@ contains
    subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   
       
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use mod_Fvar_def, only : pamb
       use probdata_module, only: T_mean, P_mean, xblob, yblob, radblob, MeanFlow
       
@@ -88,7 +88,7 @@ contains
       open(untin,file=probin(1:namlen),form='formatted',status='old')
       
 !     Set defaults
-      pamb = pphys_getP1atm_MKS()
+      pamb = PP_PA_MKS
 
       T_mean = 298.0d0
       P_mean = pamb
@@ -147,7 +147,6 @@ contains
                         delta, xlo, xhi) &
                         bind(C, name="init_data")
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : Density, Temp, FirstSpec, RhoH
       use mod_Fvar_def, only : domnlo
@@ -205,7 +204,7 @@ contains
          end do
       end do
 
-      Patm = P_mean / pphys_getP1atm_MKS()
+      Patm = P_mean / PP_PA_MKS
       press(:,:,:) = P_mean
 
       call pphys_RHOfromPTY(lo,hi, &
@@ -236,7 +235,6 @@ contains
 
    subroutine setupbc()bind(C, name="setupbc")
 
-      use PeleLM_F, only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use probdata_module, only : Y_bc, T_bc, u_bc, v_bc, rho_bc, h_bc
       use probdata_module, only : bcinit, T_mean, P_mean, MeanFlow
@@ -249,7 +247,7 @@ contains
       data  b_lo(:) / 1, 1, 1 /
       data  b_hi(:) / 1, 1, 1 /
 
-      Patm = P_mean / pphys_getP1atm_MKS()
+      Patm = P_mean / PP_PA_MKS
 
 
       Yt(1) = 0.233d0

--- a/Exec/RegTests/EB_Convection_Wave_Temperature/Prob_nd.F90
+++ b/Exec/RegTests/EB_Convection_Wave_Temperature/Prob_nd.F90
@@ -6,6 +6,7 @@
 
 #include <Prob_F.H>
 #include <PeleLM_F.H>
+#include <PPHYS_CONSTANTS.H>
 
 #include "mechanism.h"
 
@@ -43,7 +44,6 @@ contains
    subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   
       
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use mod_Fvar_def, only : pamb
       use probdata_module, only: T_mean, P_mean, xblob, yblob, radblob, MeanFlow
       
@@ -88,7 +88,7 @@ contains
       open(untin,file=probin(1:namlen),form='formatted',status='old')
       
 !     Set defaults
-      pamb = pphys_getP1atm_MKS()
+      pamb = PP_PA_MKS
 
       T_mean = 298.0d0
       P_mean = pamb
@@ -147,7 +147,6 @@ contains
                         delta, xlo, xhi) &
                         bind(C, name="init_data")
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : Density, Temp, FirstSpec, RhoH
       use mod_Fvar_def, only : domnlo
@@ -205,7 +204,7 @@ contains
          end do
       end do
 
-      Patm = P_mean / pphys_getP1atm_MKS()
+      Patm = P_mean / PP_PA_MKS
       press(:,:,:) = P_mean
 
       call pphys_RHOfromPTY(lo,hi, &
@@ -236,7 +235,6 @@ contains
 
    subroutine setupbc()bind(C, name="setupbc")
 
-      use PeleLM_F, only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use probdata_module, only : Y_bc, T_bc, u_bc, v_bc, rho_bc, h_bc
       use probdata_module, only : bcinit, T_mean, P_mean, MeanFlow
@@ -249,7 +247,7 @@ contains
       data  b_lo(:) / 1, 1, 1 /
       data  b_hi(:) / 1, 1, 1 /
 
-      Patm = P_mean / pphys_getP1atm_MKS()
+      Patm = P_mean / PP_PA_MKS
 
 
       Yt(1) = 0.233d0

--- a/Exec/RegTests/EB_FlameSheet/Prob_nd.F90
+++ b/Exec/RegTests/EB_FlameSheet/Prob_nd.F90
@@ -6,6 +6,7 @@
 
 #include <Prob_F.H>
 #include <PeleLM_F.H>
+#include <PPHYS_CONSTANTS.H>
 #include "mechanism.h"
 
 
@@ -42,8 +43,6 @@ contains
 ! ::: -----------------------------------------------------------
 
    subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
-
-      use PeleLM_F,  only: pphys_getP1atm_MKS
 
       use mod_Fvar_def, only : pamb, fuelID, domnhi, domnlo
 
@@ -103,7 +102,7 @@ contains
       open(untin,file=probin(1:namlen),form='formatted',status='old')
       
 !     Set defaults
-      pamb = pphys_getP1atm_MKS()
+      pamb = PP_PA_MKS
 
       zbase_control = 0.d0
 
@@ -164,7 +163,6 @@ contains
 
    subroutine setupbc() bind(C, name="setupbc")
 
-      use PeleLM_F, only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : pamb, domnlo, V_in
       use probdata_module, only : standoff, Y_bc, T_bc, u_bc, v_bc, w_bc, rho_bc, h_bc
@@ -178,7 +176,7 @@ contains
       data  b_lo(:) / 1, 1, 1 /
       data  b_hi(:) / 1, 1, 1 /
 
-      Patm = pamb / pphys_getP1atm_MKS()
+      Patm = pamb / PP_PA_MKS
 
 !     Take fuel mixture from pmf file
 #if ( AMREX_SPACEDIM == 2 )
@@ -268,7 +266,6 @@ contains
                         delta, xlo, xhi) &
                         bind(C, name="init_data")
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : Density, Temp, FirstSpec, RhoH, pamb
       use mod_Fvar_def, only : domnhi, domnlo
@@ -357,7 +354,7 @@ contains
          end do
       end do
          
-      Patm = pamb / pphys_getP1atm_MKS()
+      Patm = pamb / PP_PA_MKS
 
       call pphys_RHOfromPTY(lo,hi, &
                             scal(:,:,:,Density),   s_lo, s_hi, &

--- a/Exec/RegTests/EB_FlowPastCylinder/Prob_nd.F90
+++ b/Exec/RegTests/EB_FlowPastCylinder/Prob_nd.F90
@@ -6,6 +6,7 @@
 
 #include <Prob_F.H>
 #include <PeleLM_F.H>
+#include <PPHYS_CONSTANTS.H>
 
 #include "mechanism.h"
 
@@ -43,7 +44,6 @@ contains
    subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   
       
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use mod_Fvar_def, only : pamb
       use probdata_module, only: T_mean, P_mean, xblob, yblob, radblob, MeanFlow
       
@@ -88,7 +88,7 @@ contains
       open(untin,file=probin(1:namlen),form='formatted',status='old')
       
 !     Set defaults
-      pamb = pphys_getP1atm_MKS()
+      pamb = PP_PA_MKS
 
       T_mean = 298.0d0
       P_mean = pamb
@@ -147,7 +147,6 @@ contains
                         delta, xlo, xhi) &
                         bind(C, name="init_data")
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : Density, Temp, FirstSpec, RhoH
       use mod_Fvar_def, only : domnlo
@@ -204,7 +203,7 @@ contains
          end do
       end do
 
-      Patm = P_mean / pphys_getP1atm_MKS()
+      Patm = P_mean / PP_PA_MKS
 
       call pphys_RHOfromPTY(lo,hi, &
                             scal(:,:,:,Density),   s_lo, s_hi, &
@@ -234,7 +233,6 @@ contains
 
    subroutine setupbc()bind(C, name="setupbc")
 
-      use PeleLM_F, only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use probdata_module, only : Y_bc, T_bc, u_bc, v_bc, rho_bc, h_bc
       use probdata_module, only : bcinit, T_mean, P_mean, MeanFlow
@@ -247,7 +245,7 @@ contains
       data  b_lo(:) / 1, 1, 1 /
       data  b_hi(:) / 1, 1, 1 /
 
-      Patm = P_mean / pphys_getP1atm_MKS()
+      Patm = P_mean / PP_PA_MKS
 
 
       Yt(1) = 0.233d0

--- a/Exec/RegTests/FlameSheet/Prob_nd.F90
+++ b/Exec/RegTests/FlameSheet/Prob_nd.F90
@@ -43,7 +43,6 @@ contains
 
    subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
 
       use mod_Fvar_def, only : pamb, fuelID, domnhi, domnlo
 
@@ -103,7 +102,7 @@ contains
       open(untin,file=probin(1:namlen),form='formatted',status='old')
       
 !     Set defaults
-      pamb = pphys_getP1atm_MKS()
+      pamb = PP_PA_MKS
 
       zbase_control = 0.d0
 
@@ -164,7 +163,6 @@ contains
 
    subroutine setupbc() bind(C, name="setupbc")
 
-      use PeleLM_F, only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : pamb, domnlo, V_in
       use probdata_module, only : standoff, Y_bc, T_bc, u_bc, v_bc, w_bc, rho_bc, h_bc
@@ -178,7 +176,7 @@ contains
       data  b_lo(:) / 1, 1, 1 /
       data  b_hi(:) / 1, 1, 1 /
 
-      Patm = pamb / pphys_getP1atm_MKS()
+      Patm = pamb / PP_PA_MKS
 
 !     Take fuel mixture from pmf file
 #if ( AMREX_SPACEDIM == 2 )
@@ -268,7 +266,6 @@ contains
                         delta, xlo, xhi) &
                         bind(C, name="init_data")
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : Density, Temp, FirstSpec, RhoH, pamb
       use mod_Fvar_def, only : domnhi, domnlo
@@ -357,7 +354,7 @@ contains
          end do
       end do
          
-      Patm = pamb / pphys_getP1atm_MKS()
+      Patm = pamb / PP_PA_MKS
 
       call pphys_RHOfromPTY(lo,hi, &
                             scal(:,:,:,Density),   s_lo, s_hi, &

--- a/Exec/RegTests/FlameSheet/Prob_nd.F90
+++ b/Exec/RegTests/FlameSheet/Prob_nd.F90
@@ -4,8 +4,10 @@
 #include <AMReX_BC_TYPES.H>
 #include <AMReX_ArrayLim.H>
 
+
 #include <Prob_F.H>
 #include <PeleLM_F.H>
+#include "PPHYS_CONSTANTS.H"
 #include "mechanism.h"
 
 
@@ -163,7 +165,7 @@ contains
 
    subroutine setupbc() bind(C, name="setupbc")
 
-      use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
+      use PeleLM_nd, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : pamb, domnlo, V_in
       use probdata_module, only : standoff, Y_bc, T_bc, u_bc, v_bc, w_bc, rho_bc, h_bc
       use probdata_module, only : bcinit

--- a/Exec/RegTests/FlameSheetGPU/Prob_nd.F90
+++ b/Exec/RegTests/FlameSheetGPU/Prob_nd.F90
@@ -6,6 +6,7 @@
 
 #include <Prob_F.H>
 #include <PeleLM_F.H>
+#include <PPHYS_CONSTANTS.H>
 #include "mechanism.h"
 
 
@@ -43,7 +44,6 @@ contains
 
    subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
 
       use mod_Fvar_def, only : pamb, fuelID, domnhi, domnlo
 
@@ -103,7 +103,7 @@ contains
       open(untin,file=probin(1:namlen),form='formatted',status='old')
       
 !     Set defaults
-      pamb = pphys_getP1atm_MKS()
+      pamb = PP_PA_MKS
 
       zbase_control = 0.d0
 
@@ -164,7 +164,6 @@ contains
 
    subroutine setupbc() bind(C, name="setupbc")
 
-      use PeleLM_F, only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : pamb, domnlo, V_in
       use probdata_module, only : standoff, Y_bc, T_bc, u_bc, v_bc, w_bc, rho_bc, h_bc
@@ -178,7 +177,7 @@ contains
       data  b_lo(:) / 1, 1, 1 /
       data  b_hi(:) / 1, 1, 1 /
 
-      Patm = pamb / pphys_getP1atm_MKS()
+      Patm = pamb / PP_PA_MKS
 
 !     Take fuel mixture from pmf file
 #if ( AMREX_SPACEDIM == 2 )
@@ -268,7 +267,6 @@ contains
                         delta, xlo, xhi) &
                         bind(C, name="init_data")
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : Density, Temp, FirstSpec, RhoH, pamb
       use mod_Fvar_def, only : domnhi, domnlo
@@ -357,7 +355,7 @@ contains
          end do
       end do
          
-      Patm = pamb / pphys_getP1atm_MKS()
+      Patm = pamb / PP_PA_MKS
 
       call pphys_RHOfromPTY(lo,hi, &
                             scal(:,:,:,Density),   s_lo, s_hi, &

--- a/Exec/RegTests/ForcedHIT/Prob_nd.F90
+++ b/Exec/RegTests/ForcedHIT/Prob_nd.F90
@@ -6,6 +6,7 @@
 
 #include <Prob_F.H>
 #include <PeleLM_F.H>
+#include <PPHYS_CONSTANTS.H>
 
 #include "mechanism.h"
 
@@ -42,7 +43,6 @@ contains
 
    subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
 
       use mod_Fvar_def, only : pamb
       use mod_Fvar_def, only : domnhi, domnlo
@@ -122,7 +122,7 @@ contains
       open(untin,file=probin(1:namlen),form='formatted',status='old')
 
 !     Set defaults
-      pamb = pphys_getP1atm_MKS()
+      pamb = PP_PA_MKS
 
       T_in = 300.0d0
 
@@ -510,7 +510,6 @@ contains
                         delta, xlo, xhi) &
                         bind(C, name="init_data")
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : Density, Temp, FirstSpec, RhoH, pamb
       use mod_Fvar_def, only : domnlo
@@ -556,7 +555,7 @@ contains
          end do
       end do
 
-      Patm = pamb / pphys_getP1atm_MKS()
+      Patm = pamb /PP_PA_MKS
 
       call pphys_RHOfromPTY(lo,hi, &
                             scal(:,:,:,Density),   s_lo, s_hi, &

--- a/Exec/RegTests/HIT/Prob_nd.F90
+++ b/Exec/RegTests/HIT/Prob_nd.F90
@@ -6,6 +6,7 @@
 
 #include <Prob_F.H>
 #include <PeleLM_F.H>
+#include <PPHYS_CONSTANTS.H>
 
 #include "mechanism.h"
 
@@ -44,7 +45,6 @@ contains
    subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use amrex_paralleldescriptor_module, only: amrex_pd_ioprocessor
       use mod_Fvar_def, only : pamb
       use extern_probin_module, only: const_viscosity, const_bulk_viscosity, const_conductivity, const_diffusivity, mks_unit
@@ -116,7 +116,7 @@ contains
       open(untin,file=probin(1:namlen),form='formatted',status='old')
       
 !     Set defaults
-      pamb = pphys_getP1atm_MKS()
+      pamb = PP_PA_MKS
 
 
       read(untin,fortin)
@@ -249,7 +249,6 @@ contains
                         delta, xlo, xhi) &
                         bind(C, name="init_data")
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : Density, Temp, FirstSpec, RhoH, domnlo
 
@@ -380,7 +379,7 @@ contains
          end do
       end do
 
-      Patm = P_mean / pphys_getP1atm_MKS()
+      Patm = P_mean / PP_PA_MKS
 
       call pphys_RHOfromPTY(lo,hi, &
                             scal(:,:,:,Density),   s_lo, s_hi, &

--- a/Exec/RegTests/NaturalConvection/Prob_nd.F90
+++ b/Exec/RegTests/NaturalConvection/Prob_nd.F90
@@ -8,6 +8,7 @@
 #include <PeleLM_F.H>
 
 #include "mechanism.h"
+#include <PPHYS_CONSTANTS.H>
 
 module prob_nd_module
 
@@ -42,7 +43,6 @@ contains
 
    subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
 
       use mod_Fvar_def, only : pamb
 
@@ -91,7 +91,7 @@ contains
       open(untin,file=probin(1:namlen),form='formatted',status='old')
 
 !     Set defaults
-      pamb = pphys_getP1atm_MKS()
+      pamb = PP_PA_MKS
 
       T_mean = 600.0d0
       Tc = 300.0d0
@@ -145,7 +145,6 @@ contains
                         delta, xlo, xhi) &
                         bind(C, name="init_data")
                               
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : Density, Temp, FirstSpec, RhoH, pamb
       use mod_Fvar_def, only : domnlo
@@ -192,7 +191,7 @@ contains
          end do
       end do
 
-      Patm = Pamb / pphys_getP1atm_MKS()
+      Patm = Pamb / PP_PA_MKS
 
       call pphys_RHOfromPTY(lo,hi, &
                             scal(:,:,:,Density),   s_lo, s_hi, &

--- a/Exec/RegTests/NaturalConvection/user_defined_fcts_nd.F90
+++ b/Exec/RegTests/NaturalConvection/user_defined_fcts_nd.F90
@@ -3,6 +3,7 @@
 #include <AMReX_BC_TYPES.H>
 #include <PeleLM_F.H>
 #include <AMReX_ArrayLim.H>
+#include <PPHYS_CONSTANTS.H>
 
 module user_defined_fcts_nd_module
 
@@ -26,7 +27,6 @@ contains
                           vel, rho, Yl, T, h)&
                           bind(C, name="bcfunction")
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : pamb
       use probdata_module, only : Tc, Th 
@@ -62,7 +62,7 @@ contains
         Yl(0) = 0.233d0
         Yl(1) = 0.767d0
 
-        Patm = pamb / pphys_getP1atm_MKS()
+        Patm = pamb / PP_PA_MKS
 
         call pphys_RHOfromPTY(b_lo, b_hi, &
                               rho_temp(1), b_lo, b_hi, &

--- a/Exec/RegTests/TaylorGreen/Prob_nd.F90
+++ b/Exec/RegTests/TaylorGreen/Prob_nd.F90
@@ -6,6 +6,7 @@
 
 #include <Prob_F.H>
 #include <PeleLM_F.H>
+#include <PPHYS_CONSTANTS.H>
 
 #include "mechanism.h"
 
@@ -43,7 +44,6 @@ contains
   subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
   
       
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use mod_Fvar_def, only : pamb
       use probdata_module, only: T_mean, P_mean
       
@@ -88,7 +88,7 @@ contains
       open(untin,file=probin(1:namlen),form='formatted',status='old')
       
 !     Set defaults
-      pamb = pphys_getP1atm_MKS()
+      pamb = PP_PA_MKS
 
       T_mean = 298.0d0
       P_mean = pamb
@@ -139,7 +139,6 @@ contains
                         delta, xlo, xhi) &
                         bind(C, name="init_data")
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use PeleLM_nD, only: pphys_RHOfromPTY, pphys_HMIXfromTY
       use mod_Fvar_def, only : Density, Temp, FirstSpec, RhoH
       use mod_Fvar_def, only : domnlo
@@ -189,7 +188,7 @@ contains
          end do
       end do
 
-      Patm = P_mean / pphys_getP1atm_MKS()
+      Patm = P_mean / PP_PA_MKS
 
       call pphys_RHOfromPTY(lo,hi, &
                             scal(:,:,:,Density),   s_lo, s_hi, &

--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -652,7 +652,6 @@ private:
   static int         nreactions;
   static amrex::Vector<std::string> spec_names;
   static int         floor_species;
-  static amrex::Real rgas;
   static amrex::Real prandtl;
   static amrex::Real schmidt;
   static amrex::Real constant_thick_val;
@@ -666,7 +665,6 @@ private:
   static int         hack_noavgdivu;
   static amrex::Real trac_diff_coef;
   static int         use_tranlib;
-  static amrex::Real P1atm_MKS;
   static std::string turbFile;
   static std::string fuelName;
   static std::string productName;

--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -1848,8 +1848,7 @@ PeleLM::initData ()
     DataServices::Dispatch(DataServices::ExitRequest, NULL);
     
   AmrData&                  amrData     = dataServices.AmrDataRef();
-  int nspecies;
-  pphys_get_num_spec(&nspecies);
+  int nspecies = NUM_SPECIES;
   Vector<std::string> names;
   EOS::speciesNames(names);
   Vector<std::string>        plotnames   = amrData.PlotVarNames();

--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -33,6 +33,7 @@
 #include <AMReX_MLMG.H>
 #include <NS_util.H>
 
+#include <PPHYS_CONSTANTS.H>
 #include <PeleLM_K.H>
 
 #if defined(BL_USE_NEWMECH) || defined(BL_USE_VELOCITY)
@@ -144,7 +145,6 @@ int  PeleLM::nreactions;
 Vector<std::string>  PeleLM::spec_names;
 int  PeleLM::floor_species;
 int  PeleLM::do_set_rho_to_species_sum;
-Real PeleLM::rgas;
 Real PeleLM::prandtl;
 Real PeleLM::schmidt;
 Real PeleLM::constant_thick_val;
@@ -164,7 +164,6 @@ int  PeleLM::hack_nospecdiff;
 int  PeleLM::hack_noavgdivu;
 int  PeleLM::use_tranlib;
 Real PeleLM::trac_diff_coef;
-Real PeleLM::P1atm_MKS;
 bool PeleLM::plot_reactions;
 bool PeleLM::plot_consumption;
 bool PeleLM::plot_heat_release;
@@ -400,7 +399,6 @@ PeleLM::Initialize ()
   PeleLM::nspecies                  = 0;
   PeleLM::floor_species             = 1;
   PeleLM::do_set_rho_to_species_sum = 1;
-  PeleLM::rgas                      = -1.0;
   PeleLM::prandtl                   = .7;
   PeleLM::schmidt                   = .7;
   PeleLM::constant_thick_val        = -1;
@@ -421,7 +419,6 @@ PeleLM::Initialize ()
   PeleLM::hack_noavgdivu            = 0;
   PeleLM::use_tranlib               = 0;
   PeleLM::trac_diff_coef            = 0.0;
-  PeleLM::P1atm_MKS                 = -1.0;
   PeleLM::turbFile                  = "";
   PeleLM::plot_reactions            = false;
   PeleLM::plot_consumption          = true;
@@ -1255,22 +1252,7 @@ PeleLM::init_once ()
        pp.get(ppStr.c_str(),typical_values_FileVals[otherKeys[i]]);
      }
    }
-   //
-   // Get universal gas constant from Fortran.
-   //
-   rgas = pphys_getRuniversal();
-   P1atm_MKS = pphys_getP1atm_MKS();
 
-   if (rgas <= 0.0)
-   {
-     std::cerr << "PeleLM::init_once(): bad rgas: " << rgas << '\n';
-     amrex::Abort();
-   }
-   if (P1atm_MKS <= 0.0)
-   {
-     std::cerr << "PeleLM::init_once(): bad P1atm_MKS: " << P1atm_MKS << '\n';
-     amrex::Abort();
-   }
    //
    // Chemistry.
    //

--- a/Source/PeleLM_F.F90
+++ b/Source/PeleLM_F.F90
@@ -27,7 +27,6 @@ module PeleLM_F
   public :: set_scal_numb, &
             set_ht_adim_common, get_pamb, &
             set_common, active_control, &
-            pphys_getP1atm_MKS, &
             pphys_TfromHYpt, set_prob_spec
 
 contains
@@ -97,28 +96,6 @@ end subroutine plm_extern_init
  
   end function pphys_getckspecname
   
-  function pphys_getRuniversal() bind(C, name="pphys_getRuniversal") result(RUNIV)
-
-    implicit none
-    double precision Ruc, Pa, RUNIV
-
-    call CKRP(RUNIV,Ruc,Pa)
-!     1 erg/(mole.K) = 1.e-4 J/(kmole.K)
-    RUNIV = RUNIV*1.d-4
-
-  end function pphys_getRuniversal
-
-  function pphys_getP1atm_MKS() bind(C, name="pphys_getP1atm_MKS") result(P1ATM)
-
-    implicit none
-    double precision Ru, Ruc, P1ATM
-
-    call CKRP(Ru,Ruc,P1ATM)
-!     1 N/(m.m) = 0.1 dyne/(cm.cm)
-    P1ATM = P1ATM*1.d-1
-
-  end function pphys_getP1atm_MKS
-
   function pphys_numReactions() bind(C, name="pphys_numReactions") result(NR)
 
     implicit none

--- a/Source/PeleLM_F.F90
+++ b/Source/PeleLM_F.F90
@@ -87,15 +87,6 @@ end subroutine plm_extern_init
  
   end function pphys_getckspecname
   
-  function pphys_numReactions() bind(C, name="pphys_numReactions") result(NR)
-
-    implicit none
-    integer NR
-
-    NR = NUM_REACTIONS
-
-  end function pphys_numReactions
-
   subroutine pphys_set_verbose_vode() bind(C, name="pphys_set_verbose_vode")
 
     use vode_module, only: verbose

--- a/Source/PeleLM_F.F90
+++ b/Source/PeleLM_F.F90
@@ -62,15 +62,6 @@ subroutine plm_extern_init(name,namlen) bind(C, name="plm_extern_init")
 
 end subroutine plm_extern_init
 
-  subroutine pphys_get_num_spec(nspec_out) bind(C, name="pphys_get_num_spec")
-
-      implicit none
-      integer(c_int), intent(out) :: nspec_out
-
-      nspec_out = NUM_SPECIES
-
-  end subroutine pphys_get_num_spec  
-
   integer function pphys_getckspecname(i, coded)
   
     use fuego_chemistry, only : L_spec_name

--- a/Source/PeleLM_F.H
+++ b/Source/PeleLM_F.H
@@ -29,11 +29,6 @@ extern "C" {
                          const BL_FORT_FAB_ARG_ANYD(T),
                          const BL_FORT_FAB_ARG_ANYD(Y));
 
-   void pphys_CPMIXfromTY(const int* lo, const int* hi,
-                                BL_FORT_FAB_ARG_ANYD(CPMIX),
-                          const BL_FORT_FAB_ARG_ANYD(T),
-                          const BL_FORT_FAB_ARG_ANYD(Y));
-
    int pphys_TfromHY(const int* lo, const int* hi,
                            BL_FORT_FAB_ARG_ANYD(T), 
                      const BL_FORT_FAB_ARG_ANYD(H),

--- a/Source/PeleLM_F.H
+++ b/Source/PeleLM_F.H
@@ -59,10 +59,6 @@ extern "C" {
                              int* len,
                              int* idx);
 
-   amrex::Real pphys_getRuniversal();
-
-   amrex::Real pphys_getP1atm_MKS();
-
    int pphys_numReactions();
 
    void pphys_set_verbose_vode ();

--- a/Source/PeleLM_F.H
+++ b/Source/PeleLM_F.H
@@ -52,8 +52,6 @@ extern "C" {
                              int* len,
                              int* idx);
 
-   int pphys_numReactions();
-
    void pphys_set_verbose_vode ();
 
    void active_control(const amrex::Real* fuelmass,

--- a/Source/PeleLM_F.H
+++ b/Source/PeleLM_F.H
@@ -48,8 +48,6 @@ extern "C" {
 
    void plm_extern_init(const int* name, const int* namlen);
 
-   void pphys_get_num_spec(int* nspec);
-
    void pphys_get_spec_index(int* spec,
                              int* len,
                              int* idx);

--- a/Source/PeleLM_setup.cpp
+++ b/Source/PeleLM_setup.cpp
@@ -481,9 +481,10 @@ PeleLM::variableSetUp ()
   init_extern();
 
   /* PelePhysics */
-  amrex::Print() << " Initialization of network, reactor and transport \n";
+  amrex::Print() << " Initialization of network (F90)... \n";
   init_network();
 
+  amrex::Print() << " Initialization of reactor... \n";
   int reactor_type = 2;
 #ifdef USE_CUDA_SUNDIALS_PP
   reactor_info(&reactor_type,&ncells_chem);
@@ -499,7 +500,9 @@ PeleLM::variableSetUp ()
 }
 #endif
 
+  amrex::Print() << " Initialization of EOS (CPP)... \n";
   EOS::init();
+  amrex::Print() << " Initialization of Transport (CPP)... \n";
   transport_init();
 
   BCRec bc;

--- a/Source/PeleLM_setup.cpp
+++ b/Source/PeleLM_setup.cpp
@@ -534,8 +534,8 @@ PeleLM::variableSetUp ()
 
 
 
-  pphys_get_num_spec(&nspecies);
-  nreactions = pphys_numReactions();
+  nspecies = NUM_SPECIES;
+  nreactions = NUM_REACTIONS;
 
 
   EOS::speciesNames(spec_names);

--- a/Source/PeleLM_setup.cpp
+++ b/Source/PeleLM_setup.cpp
@@ -510,7 +510,7 @@ PeleLM::variableSetUp ()
 
   first_spec = ++counter;
   nspecies = NUM_SPECIES;
-  nreactions = pphys_numReactions();
+  nreactions = NUM_REACTIONS;
   counter  += nspecies - 1;
   RhoH = ++counter;
   Temp = ++counter;

--- a/Source/PeleLM_setup.cpp
+++ b/Source/PeleLM_setup.cpp
@@ -509,7 +509,7 @@ PeleLM::variableSetUp ()
   int counter   = Density;
 
   first_spec = ++counter;
-  pphys_get_num_spec(&nspecies);
+  nspecies = NUM_SPECIES;
   nreactions = pphys_numReactions();
   counter  += nspecies - 1;
   RhoH = ++counter;
@@ -1140,8 +1140,7 @@ PeleLM::rhoydotSetUp()
 {
   RhoYdot_Type       = desc_lst.size();
   const int ngrow = 1;
-  int nrhoydot;
-  pphys_get_num_spec(&nrhoydot);
+  int nrhoydot = NUM_SPECIES;
 
   amrex::Print() << "RhoYdot_Type, nrhoydot = " << RhoYdot_Type << ' ' << nrhoydot << '\n';
 

--- a/Source/Src_nd/Derive_PLM_nd.F90
+++ b/Source/Src_nd/Derive_PLM_nd.F90
@@ -14,7 +14,6 @@ module derive_PLM_nd
 
   use amrex_fort_module, only : dim=>amrex_spacedim
   use amrex_error_module, only : amrex_abort
-  use fuego_chemistry
 
   implicit none
 

--- a/Source/Src_nd/PeleLM_nd.F90
+++ b/Source/Src_nd/PeleLM_nd.F90
@@ -8,8 +8,8 @@
 #include <AMReX_BC_TYPES.H>
 #include <PeleLM_F.H>
 #include <AMReX_ArrayLim.H>
+#include "PPHYS_CONSTANTS.H"
 #include "mechanism.h"
-#include <PPHYS_CONSTANTS.H>
 
 module PeleLM_nd
 
@@ -101,13 +101,12 @@ contains
       REAL_T  :: Patm
 
 ! Local
-      REAL_T  :: RU, RUC, P1ATM, Ptmp, Yt(NUM_SPECIES), SCAL
+      REAL_T  :: Ptmp, Yt(NUM_SPECIES), SCAL
       integer :: i, j, k, n
 
 !     NOTE: SCAL converts result from assumed cgs to MKS (1 g/cm^3 = 1.e3 kg/m^3)
       SCAL = one * 1000
-      CALL CKRP(RU,RUC,P1ATM)
-      Ptmp = Patm * P1ATM
+      Ptmp = Patm * PP_PA_CGS
       do k=lo(3),hi(3)
          do j=lo(2),hi(2)
             do i=lo(1),hi(1)

--- a/Source/Src_nd/PeleLM_nd.F90
+++ b/Source/Src_nd/PeleLM_nd.F90
@@ -9,6 +9,7 @@
 #include <PeleLM_F.H>
 #include <AMReX_ArrayLim.H>
 #include "mechanism.h"
+#include <PPHYS_CONSTANTS.H>
 
 module PeleLM_nd
 
@@ -230,7 +231,6 @@ contains
                                   delta, xlo, xhi)&
                                   bind(C, name="init_data_new_mech")
 
-      use PeleLM_F,  only: pphys_getP1atm_MKS
       use mod_Fvar_def, only : Density, Temp, FirstSpec, RhoH, pamb
 
       implicit none
@@ -250,7 +250,7 @@ contains
       REAL_T  :: Patm
       integer :: i, j, k, n
 
-      Patm = pamb / pphys_getP1atm_MKS()
+      Patm = pamb / PP_PA_MKS
 
       call pphys_RHOfromPTY(lo,hi, &
                             scal(:,:,:,Density),   s_lo, s_hi, &

--- a/Source/Src_nd/PeleLM_nd.F90
+++ b/Source/Src_nd/PeleLM_nd.F90
@@ -22,7 +22,7 @@ module PeleLM_nd
 
   private
 
-  public :: pphys_HMIXfromTY, pphys_RHOfromPTY, pphys_CPMIXfromTY, pphys_TfromHY, &
+  public :: pphys_HMIXfromTY, pphys_RHOfromPTY, pphys_TfromHY, &
             init_data_new_mech, &
             dqrad_fill, divu_fill, dsdt_fill, ydot_fill, rhoYdot_fill, &
             conservative_T_floor, &
@@ -120,48 +120,6 @@ contains
       end do
 
    end subroutine pphys_RHOfromPTY
-
-!=========================================================
-!  Compute mixture mean heat capacity
-!=========================================================
-
-  subroutine pphys_CPMIXfromTY(lo, hi, &
-                               CPmix, c_lo, c_hi, &
-                               T, t_lo, t_hi, &
-                               Y, y_lo, y_hi )&
-                               bind(C,name="pphys_CPMIXfromTY")
-
-      implicit none
-
-! In/Out
-      integer, intent(in) :: lo(3),   hi(3)
-      integer, intent(in) :: c_lo(3), c_hi(3)
-      integer, intent(in) :: t_lo(3), t_hi(3)
-      integer, intent(in) :: y_lo(3), y_hi(3)
-      REAL_T, dimension(c_lo(1):c_hi(1),c_lo(2):c_hi(2),c_lo(3):c_hi(3)), intent(out) :: CPmix
-      REAL_T, dimension(t_lo(1):t_hi(1),t_lo(2):t_hi(2),t_lo(3):t_hi(3)), intent(in) :: T
-      REAL_T, dimension(y_lo(1):y_hi(1),y_lo(2):y_hi(2),y_lo(3):y_hi(3),NUM_SPECIES), intent(in) :: Y
-
-! Local
-      REAL_T  :: Yt(NUM_SPECIES), SCAL
-      integer :: i, j, k, n
-
-!     NOTE: SCAL converts result from assumed cgs to MKS (1 erg/g.K = 1.e-4 J/kg.K)
-      SCAL = 1.0d-4
-
-      do k = lo(3), hi(3)
-        do j = lo(2), hi(2)
-          do i = lo(1), hi(1)
-            do n = 1, NUM_SPECIES
-               Yt(n) = Y(i,j,k,n)
-            end do
-            CALL CKCPBS(T(i,j,k),Yt,CPMIX(i,j,k))
-            CPMIX(i,j,k) = CPMIX(i,j,k) * SCAL
-          end do
-        end do
-      end do
-
-   end subroutine pphys_CPMIXfromTY
 
 !=========================================================
 !  Iterate on T until it matches Hmix and Ym

--- a/Source/Src_nd/PeleLM_nd.F90
+++ b/Source/Src_nd/PeleLM_nd.F90
@@ -13,7 +13,6 @@
 
 module PeleLM_nd
 
-  use fuego_chemistry
   use amrex_fort_module,  only : dim=>amrex_spacedim
   use amrex_error_module, only : amrex_abort
   use amrex_filcc_module, only : amrex_filccn
@@ -41,6 +40,8 @@ contains
                                T, t_lo, t_hi, &
                                Y, y_lo, y_hi)&
                                bind(C, name="pphys_HMIXfromTY")
+
+      use fuego_chemistry, only : CKHBMS
 
       implicit none
 
@@ -87,6 +88,8 @@ contains
                                T, t_lo, t_hi, &
                                Y, y_lo, y_hi, Patm) &
                                bind(C, name="pphys_RHOfromPTY")
+
+      use fuego_chemistry, only : CKRHOY
 
       implicit none
 


### PR DESCRIPTION
GPUtize compute_enthalpy_fluxes + a few pphys_** functions. 
Remove a couple unused F90 functions
Use the newly created PPHYS_CONSTANTS file of PelePhysics (see PR #83) to define Patm in Prob_nd and other places in PLM where it was needed.
Make it so that the last dep on fuego_chemistry F90 module are apparent. once Prob_nd's are cpptized we should be able to remove the network_init and all fuego_chemistry dep - as well as dvode.
In summary: not a huge stack of changes but a contribution.