### PR TITLE
An extra GpuSynchronize is needed in advect_scalar non-EB.

### DIFF
--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -6446,6 +6446,9 @@ PeleLM::compute_scalar_advection_fluxes_and_divergence (const MultiFab& Force,
                }
             });
          }
+#ifdef AMREX_USE_CUDA
+         Gpu::streamSynchronize();
+#endif
       }
    }
 #endif


### PR DESCRIPTION
Although the non-EB Godunov version of advect_scalar in IAMR is not GPU ready yet, this fixes a temporary FAB issue when alternating between CPU/GPU operations.