### PR TITLE
Lucas/dev gpu

### DIFF
--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -286,6 +286,17 @@ protected:
                              int       num_comp,
                              amrex::Real      time) override;
 
+  virtual void getForce (amrex::FArrayBox&       force,
+                         const amrex::Box&      bx,
+                         int              ngrow,
+                         int              strt_comp,
+                         int              num_comp,
+                         const amrex::Real       time,
+                         const amrex::FArrayBox& Vel,
+                         const amrex::FArrayBox& Scal,
+                         int              scalScomp) override;
+
+
   virtual void mac_sync () override;
   //
   // Crse/fine fixup functions.

--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -8450,7 +8450,6 @@ PeleLM::getForce(FArrayBox&       force,
                  const FArrayBox& Scal,
                  int              scalScomp)
 {
-   amrex::Print() << "PeleLM::getForce() \n";
    BL_ASSERT(force.box().contains(bx));
 
    const auto& velocity = Vel.array();

--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -4564,20 +4564,20 @@ PeleLM::set_htt_hmixTYP ()
    {
       htt_hmixTYP = 0;
       std::vector< std::pair<int,Box> > isects;
-      for (int k = 0; k <= finest_level; k++)
+      for (int lvl = 0; lvl <= finest_level; lvl++)
       {
-         AmrLevel&       ht = getLevel(k);
+         AmrLevel&       ht = getLevel(lvl);
          const MultiFab& S  = ht.get_new_data(State_Type);
          const BoxArray& ba = ht.boxArray();
          const DistributionMapping& dm = ht.DistributionMap();
          MultiFab hmix(ba,dm,1,0,MFInfo(),Factory());
          MultiFab::Copy(hmix,S,RhoH,0,1,0);
          MultiFab::Divide(hmix,S,Density,0,1,0);
-         if (k != finest_level)
+         if (lvl != finest_level)
          {
-            AmrLevel& htf = getLevel(k+1);
+            AmrLevel& htf = getLevel(lvl+1);
             BoxArray  baf = htf.boxArray();
-            baf.coarsen(parent->refRatio(k));
+            baf.coarsen(parent->refRatio(lvl));
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
@@ -4585,8 +4585,8 @@ PeleLM::set_htt_hmixTYP ()
             {
                auto const& h_mix = hmix.array(mfi);
                baf.intersections(ba[mfi.index()],isects);
-               for (int i = 0; i < isects.size(); i++) {
-                  amrex::ParallelFor(isects[i].second, [h_mix]
+               for (int is = 0; is < isects.size(); is++) {
+                  amrex::ParallelFor(isects[is].second, [h_mix]
                   AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                   {
                      h_mix(i,j,k) = 0.0;
@@ -4759,8 +4759,14 @@ PeleLM::predict_velocity (Real  dt)
 
       if (getForceVerbose)
         amrex::Print() << "---\nA - Predict velocity:\n Calling getForce..." << '\n';
-      getForce(tforces,bx,1,Xvel,AMREX_SPACEDIM,prev_time,Ufab,Smf[mfi],0);
+      const Box& forcebx = grow(bx,1);
+      tforces.resize(forcebx,AMREX_SPACEDIM);
+      getForce(tforces,forcebx,1,Xvel,AMREX_SPACEDIM,prev_time,Ufab,Smf[mfi],0);
       Elixir Forcei = tforces.elixir();
+      // TODO: remove StreamSynchronize when all GPU
+#ifdef AMREX_USE_CUDA
+      Gpu::streamSynchronize();
+#endif
 
       //
       // Compute the total forcing.
@@ -5593,7 +5599,7 @@ PeleLM::getFuncCountDM (const BoxArray& bxba, int ngrow)
 
 // FIXME need to be tiled  
   for (MFIter mfi(fctmpnew); mfi.isValid(); ++mfi)
-    vwrk[count++] = static_cast<long>(fctmpnew[mfi].sum<RunOn::Host>(0));
+     vwrk[count++] = static_cast<long>(fctmpnew[mfi].sum<RunOn::Host>(0));
 
   fctmpnew.clear();
 
@@ -8431,6 +8437,40 @@ PeleLM::RhoH_to_Temp (MultiFab& S,
   // Reset it back.
   //
   //htt_hmixTYP = htt_hmixTYP_SAVE;
+}
+
+void
+PeleLM::getForce(FArrayBox&       force,
+                 const Box&       bx,
+                 int              ngrow,
+                 int              scomp,
+                 int              ncomp,
+                 const Real       time,
+                 const FArrayBox& Vel,
+                 const FArrayBox& Scal,
+                 int              scalScomp)
+{
+   amrex::Print() << "PeleLM::getForce() \n";
+   BL_ASSERT(force.box().contains(bx));
+
+   const auto& velocity = Vel.array();
+   const auto& scalars  = Scal.array(scalScomp);
+   const auto& f        = force.array(scomp);
+
+   const auto  dx       = geom.CellSizeArray();
+   RealBox gridloc      = RealBox(bx,geom.CellSize(),geom.ProbLo());
+   const Real  grav     = gravity;
+   const int   nscal    = NUM_SCALARS;
+
+   // TODO: For now the following are set here. Update when active_control moved to C++
+   int pseudo_gravity    = 0;
+   const Real dV_control = 0.0;
+
+   amrex::ParallelFor(bx, [f, scalars, velocity, time, grav, pseudo_gravity, dV_control, dx, scomp, ncomp]
+   AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+   {
+      makeForce(i,j,k, scomp, ncomp, pseudo_gravity, time, grav, dV_control, dx, velocity, scalars, f);
+   });
 }
 
 void

--- a/Source/PeleLM_K.H
+++ b/Source/PeleLM_K.H
@@ -21,7 +21,8 @@ reactionRateRhoY(int i, int j, int k,
    using namespace amrex::literals;
 
    // Get rho from rhoY. Is there a better way ?
-   amrex::Real rho = 0.0_rt, rhoinv;
+   amrex::Real rho = 0.0_rt;
+   amrex::Real rhoinv;
    for (int n = 0; n < NUM_SPECIES; n++) {
       rho += rhoY(i,j,k,n);
    }
@@ -165,7 +166,8 @@ buildAdvectionForcing(int i, int j, int k,
 
    if ( closed_chamber == 1 ) forceT(i,j,k) += dp0dt;                // Add dp0/dt
 
-   amrex::Real cpmix, cpmixinv;
+   amrex::Real cpmix;
+   amrex::Real cpmixinv;
    EOS::TY2Cp(T(i,j,k), y, cpmix);
    cpmixinv = 1.0_rt / cpmix * 1.0e4_rt;                             // CGS -> MKS conversion
    forceT(i,j,k) *= rhoinv * cpmixinv;
@@ -231,7 +233,8 @@ compute_divu(int i, int j, int k,
    EOS::inv_molecular_weight(mwtinv);
 
    // Get rho & Y from rhoY
-   amrex::Real rho = 0.0_rt, rhoinv;
+   amrex::Real rho = 0.0_rt;
+   amrex::Real rhoinv;
    for (int n = 0; n < NUM_SPECIES; n++) {
       rho += rhoY(i,j,k,n);
    }
@@ -241,7 +244,9 @@ compute_divu(int i, int j, int k,
       y[n] = rhoY(i,j,k,n) * rhoinv;
    }
 
-   amrex::Real cpmix, Wbar, hi[NUM_SPECIES];;
+   amrex::Real cpmix;
+   amrex::Real Wbar;
+   amrex::Real hi[NUM_SPECIES];;
    EOS::TY2Cp(T(i,j,k), y, cpmix);
    EOS::Y2WBAR(y, Wbar);
    EOS::T2Hi(T(i,j,k), hi);
@@ -284,7 +289,8 @@ getGammaInv(int i, int j, int k,
    using namespace amrex::literals;
 
    // Get rho & Y from rhoY
-   amrex::Real rho = 0.0_rt, rhoinv;
+   amrex::Real rho = 0.0_rt;
+   amrex::Real rhoinv;
    for (int n = 0; n < NUM_SPECIES; n++) {
       rho += rhoY(i,j,k,n);
    }
@@ -294,7 +300,8 @@ getGammaInv(int i, int j, int k,
       y[n] = rhoY(i,j,k,n) * rhoinv;
    }
 
-   amrex::Real cpmix, cvmix;
+   amrex::Real cpmix;
+   amrex::Real cvmix;
    EOS::TY2Cp(T(i,j,k), y, cpmix);
    EOS::TY2Cv(T(i,j,k), y, cvmix);
    
@@ -314,7 +321,9 @@ getRhoGivenTYP(int i, int j, int k,
 {
    using namespace amrex::literals;
 
-   amrex::Real rho_cgs, P_cgs, y[NUM_SPECIES];
+   amrex::Real rho_cgs;
+   amrex::Real P_cgs;
+   amrex::Real y[NUM_SPECIES];
    P_cgs = Patm * EOS::PATM;
    for (int n = 0; n < NUM_SPECIES; n++) {
       y[n] = Y(i,j,k,n);                       // TODO: need to find a way not to do that
@@ -339,7 +348,8 @@ getTransportCoeff(int i, int j, int k,
    EOS::inv_molecular_weight(mwtinv);
 
    // Get rho & Y from rhoY
-   amrex::Real rho = 0.0_rt, rhoinv;
+   amrex::Real rho = 0.0_rt;
+   amrex::Real rhoinv;
    for (int n = 0; n < NUM_SPECIES; n++) {
       rho += rhoY(i,j,k,n);
    }
@@ -353,10 +363,16 @@ getTransportCoeff(int i, int j, int k,
    EOS::Y2WBAR(y, Wbar);
 
    rho *= 1.0e-3_rt;                          // MKS -> CGS conversion
-   amrex::Real rhoDi_cgs[NUM_SPECIES], lambda_cgs, mu_cgs, dummy_xi;
+   amrex::Real rhoDi_cgs[NUM_SPECIES];
+   amrex::Real lambda_cgs;
+   amrex::Real mu_cgs;
+   amrex::Real dummy_xi;
    amrex::Real Tloc = T(i,j,k);
 
-   bool get_xi = false, get_mu = true, get_lam = true, get_Ddiag = true;
+   bool get_xi = false;
+   bool get_mu = true;
+   bool get_lam = true;
+   bool get_Ddiag = true;
    transport(get_xi, get_mu, get_lam, get_Ddiag, Tloc,
              rho, y, rhoDi_cgs, mu_cgs, dummy_xi, lambda_cgs);
 
@@ -383,7 +399,8 @@ getTransportCoeffUnityLe(int i, int j, int k,
    using namespace amrex::literals;
 
    // Get rho & Y from rhoY
-   amrex::Real rho = 0.0_rt, rhoinv;
+   amrex::Real rho = 0.0_rt;
+   amrex::Real rhoinv;
    for (int n = 0; n < NUM_SPECIES; n++) {
       rho += rhoY(i,j,k,n);
    }
@@ -394,9 +411,15 @@ getTransportCoeffUnityLe(int i, int j, int k,
    }
 
    rho *= 1.0e-3_rt;                                     // MKS -> CGS conversion
-   amrex::Real rhoDi_cgs[NUM_SPECIES], lambda_cgs, mu_cgs, dummy_xi;
+   amrex::Real rhoDi_cgs[NUM_SPECIES];
+   amrex::Real lambda_cgs;
+   amrex::Real mu_cgs;
+   amrex::Real dummy_xi;
 
-   bool get_xi = false, get_mu = true, get_lam = false, get_Ddiag = false;
+   bool get_xi = false;
+   bool get_mu = true;
+   bool get_lam = false;
+   bool get_Ddiag = false;
    transport(get_xi, get_mu, get_lam, get_Ddiag, T(i,j,k),
              rho, y, rhoDi_cgs, mu_cgs, dummy_xi, lambda_cgs);
 
@@ -444,7 +467,8 @@ getBetaWbar(int i, int j, int k,
    using namespace amrex::literals;
 
    // Get rho & Y from rhoY
-   amrex::Real rho = 0.0_rt, rhoinv;
+   amrex::Real rho = 0.0_rt;
+   amrex::Real rhoinv;
    for (int n = 0; n < NUM_SPECIES; n++) {
       rho += rhoY(i,j,k,n);
    }
@@ -474,7 +498,8 @@ getVelViscosity(int i, int j, int k,
    using namespace amrex::literals;
 
    // Get rho & Y from rhoY
-   amrex::Real rho = 0.0_rt, rhoinv;
+   amrex::Real rho = 0.0_rt;
+   amrex::Real rhoinv;
    for (int n = 0; n < NUM_SPECIES; n++) {
       rho += rhoY(i,j,k,n);
    }
@@ -485,9 +510,15 @@ getVelViscosity(int i, int j, int k,
    }
 
    rho *= 1.0e-3_rt;                          // MKS -> CGS conversion
-   amrex::Real dummy_rhoDi[NUM_SPECIES], dummy_lambda, mu_cgs, dummy_xi;
+   amrex::Real dummy_rhoDi[NUM_SPECIES];
+   amrex::Real dummy_lambda;
+   amrex::Real mu_cgs;
+   amrex::Real dummy_xi;
 
-   bool get_xi = false, get_mu = true, get_lam = false, get_Ddiag = false;
+   bool get_xi = false;
+   bool get_mu = true;
+   bool get_lam = false;
+   bool get_Ddiag = false;
    transport(get_xi, get_mu, get_lam, get_Ddiag, T(i,j,k),
              rho, y, dummy_rhoDi, mu_cgs, dummy_xi, dummy_lambda);
 
@@ -506,7 +537,8 @@ getConductivity(int i, int j, int k,
    using namespace amrex::literals;
 
    // Get rho & Y from rhoY
-   amrex::Real rho = 0.0_rt, rhoinv;
+   amrex::Real rho = 0.0_rt;
+   amrex::Real rhoinv;
    for (int n = 0; n < NUM_SPECIES; n++) {
       rho += rhoY(i,j,k,n);
    }
@@ -517,9 +549,15 @@ getConductivity(int i, int j, int k,
    }
 
    rho *= 1.0e-3_rt;                          // MKS -> CGS conversion
-   amrex::Real dummy_rhoDi[NUM_SPECIES], dummy_mu, lambda_cgs, dummy_xi;
+   amrex::Real dummy_rhoDi[NUM_SPECIES];
+   amrex::Real lambda_cgs;
+   amrex::Real dummy_mu;
+   amrex::Real dummy_xi;
 
-   bool get_xi = false, get_mu = false, get_lam = true, get_Ddiag = false;
+   bool get_xi = false;
+   bool get_mu = false;
+   bool get_lam = true;
+   bool get_Ddiag = false;
    transport(get_xi, get_mu, get_lam, get_Ddiag, T(i,j,k),
              rho, y, dummy_rhoDi, dummy_mu, dummy_xi, lambda_cgs);
 

--- a/Source/PeleLM_K.H
+++ b/Source/PeleLM_K.H
@@ -963,13 +963,20 @@ makeForce(int i, int j, int k,
          force(i,j,k,1) = 0.0_rt;
          force(i,j,k,2) = gravity*scal(i,j,k,0);
 #endif
+      } else {
+         for (int n = 0; n < AMREX_SPACEDIM; n++) {
+            force(i,j,k,n) = 0.0_rt;
+         }
       }
+
       if (pseudo_gravity) {
          force(i,j,k,AMREX_SPACEDIM-1) += dV_control * scal(i,j,k,0);
       }
    }
-   for (int n = std::max(scomp,AMREX_SPACEDIM); n < scomp+ncomp; n++) {
-      force(i,j,k,n) = 0.0_rt;
+   if ( (scomp+ncomp) > AMREX_SPACEDIM - 1) {
+      for (int n = std::max(scomp,AMREX_SPACEDIM); n < scomp+ncomp; n++) {
+         force(i,j,k,n) = 0.0_rt;
+      }
    }
 }
 


### PR DESCRIPTION
This PR contains:
 - cleaning of multiple declaration on single line in PeleLM_K.H
 - getForce is now virtual and overwritten in PeleLM, and the force FAB need to be allocated beforehand. Adapt the calls accordingly.
This PR require PR #51 of IAMR to function properly.