### PR TITLE
bugfix active_control

### DIFF
--- a/Exec/RegTests/FlameSheet/GNUmakefile
+++ b/Exec/RegTests/FlameSheet/GNUmakefile
@@ -9,7 +9,7 @@ PELELM_HOME ?= ${TOP}/PeleLM
 
 DIM             = 2
 COMP            = gnu
-DEBUG           = TRUE
+DEBUG           = FALSE
 USE_MPI         = TRUE
 USE_OMP         = FALSE
 PRECISION       = DOUBLE

--- a/Exec/RegTests/FlameSheet/inputs.2d-regt
+++ b/Exec/RegTests/FlameSheet/inputs.2d-regt
@@ -101,8 +101,6 @@ ns.min_rho_divu_ceiling = .01
 ns.fuelName        = H2
 ns.unity_Le = 0
 
-ns.do_active_control = 0
-
 ns.do_fillPatchUMAC=1
 ns.zeroBndryVisc=1
 ns.num_divu_iters =3

--- a/Exec/RegTests/FlameSheet/pelelm_prob.cpp
+++ b/Exec/RegTests/FlameSheet/pelelm_prob.cpp
@@ -23,14 +23,6 @@ namespace ProbParm
    amrex::Vector<std::string> pmf_names;
 } // namespace ProbParm
 
-namespace ACParm
-{
-   AMREX_GPU_DEVICE_MANAGED unsigned int ctrl_active = 0;
-   AMREX_GPU_DEVICE_MANAGED amrex::Real  ctrl_dV = 0.0;
-   AMREX_GPU_DEVICE_MANAGED amrex::Real  ctrl_V_in = 0.0;
-   AMREX_GPU_DEVICE_MANAGED amrex::Real  ctrl_tBase = 0.0;
-}
-
 std::string
 read_pmf_file(std::ifstream& in)
 {

--- a/Exec/RegTests/FlameSheetGPU/inputs.2d-regt
+++ b/Exec/RegTests/FlameSheetGPU/inputs.2d-regt
@@ -101,8 +101,6 @@ ns.min_rho_divu_ceiling = .01
 ns.fuelName        = H2
 ns.unity_Le = 0
 
-ns.do_active_control = 0
-
 ns.do_fillPatchUMAC=1
 ns.zeroBndryVisc=1
 ns.num_divu_iters =3

--- a/Exec/RegTests/FlameSheetGPU/pelelm_prob.cpp
+++ b/Exec/RegTests/FlameSheetGPU/pelelm_prob.cpp
@@ -22,14 +22,6 @@ namespace ProbParm
    amrex::Vector<std::string> pmf_names;
 } // namespace ProbParm
 
-namespace ACParm
-{
-   AMREX_GPU_DEVICE_MANAGED unsigned int ctrl_active = 0;
-   AMREX_GPU_DEVICE_MANAGED amrex::Real  ctrl_dV = 0.0;
-   AMREX_GPU_DEVICE_MANAGED amrex::Real  ctrl_V_in = 0.0;
-   AMREX_GPU_DEVICE_MANAGED amrex::Real  ctrl_tBase = 0.0;
-}
-
 std::string
 read_pmf_file(std::ifstream& in)
 {

--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -93,6 +93,14 @@ const int  LinOp_grow  = 1;
 static Real              typical_RhoH_value_default = -1.e10;
 static const std::string typical_values_filename("typical_values.fab");
 
+namespace ACParm
+{
+   AMREX_GPU_DEVICE_MANAGED unsigned int ctrl_active = 0;
+   AMREX_GPU_DEVICE_MANAGED amrex::Real  ctrl_dV = 0.0;
+   AMREX_GPU_DEVICE_MANAGED amrex::Real  ctrl_V_in = 0.0;
+   AMREX_GPU_DEVICE_MANAGED amrex::Real  ctrl_tBase = 0.0;
+}
+
 namespace
 {
   bool initialized = false;


### PR DESCRIPTION
bugfix active_control, as it is looking to the parmparse parameters by default they are now defined in PeleLM.cpp