### PR TITLE
Use NBS::average_down. amrex::average_down is not EB aware.

### DIFF
--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -2086,8 +2086,7 @@ PeleLM::post_timestep (int crse_iteration)
       MultiFab& Ydot_crse = *(clev.auxDiag["REACTIONS"]);
       MultiFab& Ydot_fine = *(flev.auxDiag["REACTIONS"]);
 
-      amrex::average_down(Ydot_fine, Ydot_crse, flev.geom, clev.geom,
-                           0, Ndiag, parent->refRatio(i-1));
+      clev.average_down(Ydot_fine, Ydot_crse, 0, Ndiag);
     }
   }
 }
@@ -2256,8 +2255,7 @@ PeleLM::post_init (Real stop_time)
       MultiFab& Divu_crse = crse_lev.get_new_data(Divu_Type);
       MultiFab& Divu_fine = fine_lev.get_new_data(Divu_Type);
 
-      amrex::average_down(Divu_fine, Divu_crse, fine_lev.geom, crse_lev.geom,
-                           0, 1, crse_lev.fine_ratio);
+      crse_lev.average_down(Divu_fine, Divu_crse, 0, 1);
     }
 
     // compute number of cells
@@ -2352,8 +2350,7 @@ PeleLM::post_init (Real stop_time)
           MultiFab& Divu_crse = crse_lev.get_new_data(Divu_Type);
           MultiFab& Divu_fine = fine_lev.get_new_data(Divu_Type);
 
-          amrex::average_down(Divu_fine, Divu_crse, fine_lev.geom, crse_lev.geom,
-                               0, 1, crse_lev.fine_ratio);
+	  crse_lev.average_down(Divu_fine, Divu_crse, 0, 1);
         }
       }
       //
@@ -2404,8 +2401,7 @@ PeleLM::post_init (Real stop_time)
         MultiFab&       S_fine  = getLevel(k+1).get_new_data(State_Type);
         MultiFab&       S_crse  = getLevel(k).get_new_data(State_Type);
 
-        amrex::average_down(S_fine, S_crse, fine_lev.geom, crse_lev.geom,
-                             Xvel, AMREX_SPACEDIM, getLevel(k).fine_ratio);
+	crse_lev.average_down(S_fine, S_crse, Xvel, AMREX_SPACEDIM);
       }
     }
     //
@@ -2637,8 +2633,7 @@ PeleLM::post_init_press (Real&        dt_init,
         MultiFab& Divu_crse = crse_lev.get_new_data(Divu_Type);
         MultiFab& Divu_fine = fine_lev.get_new_data(Divu_Type);
 
-        amrex::average_down(Divu_fine, Divu_crse, fine_lev.geom, crse_lev.geom,
-                             0, 1, crse_lev.fine_ratio);
+	crse_lev.average_down(Divu_fine, Divu_crse, 0, 1);
       }
 
       // compute Sbar and subtract from S
@@ -2662,8 +2657,7 @@ PeleLM::post_init_press (Real&        dt_init,
         MultiFab& Divu_crse = crse_lev.get_old_data(Divu_Type);
         MultiFab& Divu_fine = fine_lev.get_old_data(Divu_Type);
 
-        amrex::average_down(Divu_fine, Divu_crse, fine_lev.geom, crse_lev.geom,
-                             0, 1, crse_lev.fine_ratio);
+	crse_lev.average_down(Divu_fine, Divu_crse, 0, 1);
       }
 
       // compute Sbar and subtract from S
@@ -2778,8 +2772,7 @@ PeleLM::avgDown ()
    MultiFab&       S_crse    = get_new_data(State_Type);
    MultiFab&       S_fine    = fine_lev.get_new_data(State_Type);
 
-   amrex::average_down(S_fine, S_crse, fine_lev.geom, geom,
-                       0, S_crse.nComp(), fine_ratio);
+   average_down(S_fine, S_crse, 0, S_crse.nComp());
    //
    // Fill rho_ctime at the current and finer levels with the correct data.
    //
@@ -2820,8 +2813,7 @@ PeleLM::avgDown ()
      MultiFab& Divu_crse = get_new_data(Divu_Type);
      MultiFab& Divu_fine = fine_lev.get_new_data(Divu_Type);
 
-     amrex::average_down(Divu_fine, Divu_crse, fine_lev.geom, geom,
-                          0, Divu_crse.nComp(), fine_ratio);
+     average_down(Divu_fine, Divu_crse, 0, Divu_crse.nComp());
    }
 
    get_new_data(Dsdt_Type).setVal(0.0);
@@ -5794,8 +5786,7 @@ PeleLM::advance_chemistry (MultiFab&       mf_old,
     if (do_avg_down_chem)
     {
       MultiFab& fine_React = getLevel(level+1).get_old_data(RhoYdot_Type);
-      amrex::average_down(fine_React, React_new, getLevel(level+1).geom, geom,
-                           0, NUM_SPECIES, fine_ratio);
+      average_down(fine_React, React_new, 0, NUM_SPECIES);
     }
     //
     // Ensure consistent grow cells.
@@ -6962,8 +6953,7 @@ PeleLM::mac_sync ()
         MultiFab& S_crse_loc = crse_level.get_new_data(State_Type);
         MultiFab& S_fine_loc = fine_level.get_new_data(State_Type);
 
-        amrex::average_down(S_fine_loc, S_crse_loc, fine_level.geom, crse_level.geom,
-                            RhoRT, 1, crse_level.fine_ratio);
+	crse_level.average_down(S_fine_loc, S_crse_loc, RhoRT, 1);
       }
       PeleLM& fine_level = getLevel(level+1);
       showMF("DBGSync",fine_level.get_new_data(State_Type),"sdc_SnewFine_EndSyncIter",level+1,mac_sync_iter,parent->levelSteps(level));
@@ -7131,8 +7121,7 @@ PeleLM::mac_sync ()
      MultiFab& S_crse_loc = crse_level.get_new_data(State_Type);
      MultiFab& S_fine_loc = fine_level.get_new_data(State_Type);
 
-     amrex::average_down(S_fine_loc, S_crse_loc, fine_level.geom, crse_level.geom,
-                         RhoRT, 1, crse_level.fine_ratio);
+     crse_level.average_down(S_fine_loc, S_crse_loc, RhoRT, 1);
    }
    BL_PROFILE_VAR_STOP(PLM_SSYNC);
 


### PR DESCRIPTION
NSB::average_down calls `amrex::average_down` for non-EB and `amrex::EB_average_down` for EB. I tested this in  `Exec/RegTests/FlameSheet` and got zero diffs. 