### PR TITLE
DdWbar in mac_sync needs to be defined with EBFactory otherwise the

### DIFF
--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -6585,7 +6585,7 @@ PeleLM::mac_sync ()
          compute_Wbar_fluxes(curr_time,1,-1.0);
 
          // take divergence of beta grad delta Wbar
-         DdWbar.define(grids,dmap,NUM_SPECIES,nGrowAdvForcing);
+         DdWbar.define(grids,dmap,NUM_SPECIES,nGrowAdvForcing,MFInfo(),Factory());
          MultiFab* const * fluxWbar = SpecDiffusionFluxWbar;
          flux_divergence(DdWbar,0,fluxWbar,0,NUM_SPECIES,-1);
          DdWbar.mult(dt);


### PR DESCRIPTION
redistribution in flux_divergence fails.