### PR TITLE
Add running cases to the CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -149,7 +149,7 @@ jobs:
     - name: Run
       working-directory: ./Exec/RegTests/FlameSheet/
       run: |
-        ./PeleLM2d.gnu.ex inputs.2d_regt max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0
+        ./PeleLM2d.gnu.ex inputs.2d-regt max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0
 
   # Build and Run the CoVo RegTest with GNU7.5 and no MPI support
   COVO2D_NoMPIRun:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -142,10 +142,11 @@ jobs:
          IAMR_HOME: ${GITHUB_WORKSPACE}/build/IAMR
          PELE_PHYSICS_HOME: ${GITHUB_WORKSPACE}/build/PelePhysics
          PELELM_HOME: ${GITHUB_WORKSPACE}
-      build: |
+      run: |
         working-directory: Exec/RegTests/FlameSheet/
         make TPL COMP=gnu USE_MPI=FALSE DEBUG=FALSE
         make -j 2 COMP=gnu USE_MPI=FALSE DEBUG=FALSE
+    - name: Run
       run: |
         working-directory: Exec/RegTests/FlameSheet/
         ./PeleLM2d.gnu.ex inputs.2d_regt max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0
@@ -168,10 +169,11 @@ jobs:
          IAMR_HOME: ${GITHUB_WORKSPACE}/build/IAMR
          PELE_PHYSICS_HOME: ${GITHUB_WORKSPACE}/build/PelePhysics
          PELELM_HOME: ${GITHUB_WORKSPACE}
-      build: |
+      run: |
         working-directory: Exec/RegTests/PeriodicCases/
         make TPL COMP=gnu USE_MPI=FALSE
         make -j 2 COMP=gnu USE_MPI=FALSE
+    - name: Run
       run: |
         working-directory: Exec/RegTests/PeriodicCases/
         ./PeleLM2d.gnu.ex inputs.2d_CoVo_RegT_negX max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0
@@ -194,10 +196,11 @@ jobs:
          IAMR_HOME: ${GITHUB_WORKSPACE}/build/IAMR
          PELE_PHYSICS_HOME: ${GITHUB_WORKSPACE}/build/PelePhysics
          PELELM_HOME: ${GITHUB_WORKSPACE}
-      build: |
+      run: |
         working-directory: Exec/RegTests/EB_FlowPastCylinder/
         make TPL COMP=gnu
         make -j 2 COMP=gnu
+    - name: Run
       run: |
         working-directory: Exec/RegTests/EB_FlowPastCylinder/
         mpirun -n 2 ./PeleLM2d.gnu.MPI.ex inputs.2d-regt_VS max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0
@@ -220,10 +223,11 @@ jobs:
          IAMR_HOME: ${GITHUB_WORKSPACE}/build/IAMR
          PELE_PHYSICS_HOME: ${GITHUB_WORKSPACE}/build/PelePhysics
          PELELM_HOME: ${GITHUB_WORKSPACE}
-      build: |
+      run: |
         working-directory: Exec/RegTests/EB_FlowPastCylinder/
         make TPL COMP=gnu DIM=3
         make -j 2 COMP=gnu DIM=3
+    - name: Run
       run: |
         working-directory: Exec/RegTests/EB_FlowPastCylinder/
         mpirun -n 4 ./PeleLM3d.gnu.MPI.ex inputs.3d-regt_VS max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -142,10 +142,12 @@ jobs:
          IAMR_HOME: ${GITHUB_WORKSPACE}/build/IAMR
          PELE_PHYSICS_HOME: ${GITHUB_WORKSPACE}/build/PelePhysics
          PELELM_HOME: ${GITHUB_WORKSPACE}
-      run: |
-        cd Exec/RegTests/PeriodicCases/
+      build: |
+        working-directory: Exec/RegTests/PeriodicCases/
         make TPL COMP=gnu USE_MPI=FALSE
         make -j 2 COMP=gnu USE_MPI=FALSE
+      run: |
+        working-directory: Exec/RegTests/PeriodicCases/
         ./PeleLM2d.gnu.ex inputs.2d_CoVo_RegT_negX max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0
   
   # Build and Run the FPC RegTest with GNU7.5 and MPI support
@@ -166,10 +168,12 @@ jobs:
          IAMR_HOME: ${GITHUB_WORKSPACE}/build/IAMR
          PELE_PHYSICS_HOME: ${GITHUB_WORKSPACE}/build/PelePhysics
          PELELM_HOME: ${GITHUB_WORKSPACE}
-      run: |
-        cd Exec/RegTests/EB_FlowPastCylinder/
+      build: |
+        working-directory: Exec/RegTests/EB_FlowPastCylinder/
         make TPL COMP=gnu
         make -j 2 COMP=gnu
+      run: |
+        working-directory: Exec/RegTests/EB_FlowPastCylinder/
         mpirun -n 2 ./PeleLM2d.gnu.MPI.ex inputs.2d-regt_VS max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0
   
   # Build and Run the 3D FPC RegTest with GNU7.5 and MPI support
@@ -190,8 +194,10 @@ jobs:
          IAMR_HOME: ${GITHUB_WORKSPACE}/build/IAMR
          PELE_PHYSICS_HOME: ${GITHUB_WORKSPACE}/build/PelePhysics
          PELELM_HOME: ${GITHUB_WORKSPACE}
-      run: |
-        cd Exec/RegTests/EB_FlowPastCylinder/
+      build: |
+        working-directory: Exec/RegTests/EB_FlowPastCylinder/
         make TPL COMP=gnu DIM=3
         make -j 2 COMP=gnu DIM=3
+      run: |
+        working-directory: Exec/RegTests/EB_FlowPastCylinder/
         mpirun -n 4 ./PeleLM3d.gnu.MPI.ex inputs.3d-regt_VS max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -124,6 +124,32 @@ jobs:
         make TPL COMP=gnu USE_CUDA=TRUE
         make -j 2 COMP=gnu USE_CUDA=TRUE
 
+  #Build and run the 2D FlameSheet RegTest with GNU7.5 and no MPI support
+  FS2D_NoMPIRun:
+    name: GNU@7.5 NOMPI Run [FS2D]
+    runs-on: ubuntu-latest
+    env: 
+      {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
+    steps:
+    - uses: actions/checkout@v2
+    - name: System Dependencies
+      run: .github/workflows/dependencies/dependencies.sh
+    - name: Repo Dependencies
+      run: Tools/CloneDeps.sh
+    - name: Build
+      env:
+         AMREX_HOME: ${GITHUB_WORKSPACE}/build/amrex
+         IAMR_HOME: ${GITHUB_WORKSPACE}/build/IAMR
+         PELE_PHYSICS_HOME: ${GITHUB_WORKSPACE}/build/PelePhysics
+         PELELM_HOME: ${GITHUB_WORKSPACE}
+      build: |
+        working-directory: Exec/RegTests/FlameSheet/
+        make TPL COMP=gnu USE_MPI=FALSE DEBUG=FALSE
+        make -j 2 COMP=gnu USE_MPI=FALSE DEBUG=FALSE
+      run: |
+        working-directory: Exec/RegTests/FlameSheet/
+        ./PeleLM2d.gnu.ex inputs.2d_regt max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0
+
   # Build and Run the CoVo RegTest with GNU7.5 and no MPI support
   COVO2D_NoMPIRun:
     name: GNU@7.5 NOMPI Run [COVO2D]

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   #Build the 2D FlameSheet RegTest with GNU7.5 and no MPI support
   FS2D_NoMPI:
-    name: GNU@7.5 NOMPI [FS2D]
+    name: GNU@7.5 NOMPI Comp [FS2D]
     runs-on: ubuntu-latest
     env: 
       {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
@@ -33,7 +33,7 @@ jobs:
   
   # Build the 2D FlameSheet RegTest with GNU7.5 and MPI support
   FS2D_MPI:
-    name: GNU@7.5 MPI [FS2D]
+    name: GNU@7.5 MPI Comp [FS2D]
     runs-on: ubuntu-latest
     env: 
       {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
@@ -56,7 +56,7 @@ jobs:
   
   # Build the 2D FlameSheet RegTest with GNU7.5 and MPI+OMP support
   FS2D_MPIOMP:
-    name: GNU@7.5 MPI OMP [FS2D]
+    name: GNU@7.5 MPI OMP Comp [FS2D]
     runs-on: ubuntu-latest
     env: 
       {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
@@ -79,7 +79,7 @@ jobs:
   
   # Build the 3D FlameSheet RegTest with GNU7.5 and MPI support
   FS3D_MPI:
-    name: GNU@7.5 MPI [FS3D]
+    name: GNU@7.5 MPI Comp [FS3D]
     runs-on: ubuntu-latest
     env: 
       {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
@@ -102,7 +102,7 @@ jobs:
 
   # Build the 2D FlameSheet RegTest with CUDA and MPI support
   FS2D_CUDA:
-    name: CUDA@11.0.1 [FS2D]
+    name: CUDA@11.0.1 Comp [FS2D]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -123,3 +123,75 @@ jobs:
         make help COMP=gnu USE_CUDA=TRUE
         make TPL COMP=gnu USE_CUDA=TRUE
         make -j 2 COMP=gnu USE_CUDA=TRUE
+
+  # Build and Run the CoVo RegTest with GNU7.5 and no MPI support
+  COVO2D_NoMPIRun:
+    name: GNU@7.5 NOMPI Run [COVO2D]
+    runs-on: ubuntu-latest
+    env: 
+      {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
+    steps:
+    - uses: actions/checkout@v2
+    - name: System Dependencies
+      run: .github/workflows/dependencies/dependencies.sh
+    - name: Repo Dependencies
+      run: Tools/CloneDeps.sh
+    - name: Build
+      env:
+         AMREX_HOME: ${GITHUB_WORKSPACE}/build/amrex
+         IAMR_HOME: ${GITHUB_WORKSPACE}/build/IAMR
+         PELE_PHYSICS_HOME: ${GITHUB_WORKSPACE}/build/PelePhysics
+         PELELM_HOME: ${GITHUB_WORKSPACE}
+      run: |
+        cd Exec/RegTests/PeriodicCases/
+        make TPL COMP=gnu USE_MPI=FALSE
+        make -j 2 COMP=gnu USE_MPI=FALSE
+        ./PeleLM2d.gnu.ex inputs.2d_CoVo_RegT_negX max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0
+  
+  # Build and Run the FPC RegTest with GNU7.5 and MPI support
+  FPC2D_MPIRun:
+    name: GNU@7.5 MPI Run [FPC2D]
+    runs-on: ubuntu-latest
+    env: 
+      {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
+    steps:
+    - uses: actions/checkout@v2
+    - name: System Dependencies
+      run: .github/workflows/dependencies/dependencies.sh
+    - name: Repo Dependencies
+      run: Tools/CloneDeps.sh
+    - name: Build
+      env:
+         AMREX_HOME: ${GITHUB_WORKSPACE}/build/amrex
+         IAMR_HOME: ${GITHUB_WORKSPACE}/build/IAMR
+         PELE_PHYSICS_HOME: ${GITHUB_WORKSPACE}/build/PelePhysics
+         PELELM_HOME: ${GITHUB_WORKSPACE}
+      run: |
+        cd Exec/RegTests/EB_FlowPastCylinder/
+        make TPL COMP=gnu
+        make -j 2 COMP=gnu
+        mpirun -n 2 ./PeleLM2d.gnu.MPI.ex inputs.2d-regt_VS max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0
+  
+  # Build and Run the 3D FPC RegTest with GNU7.5 and MPI support
+  FPC3D_MPIRun:
+    name: GNU@7.5 MPI Run [FPC3D]
+    runs-on: ubuntu-latest
+    env: 
+      {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
+    steps:
+    - uses: actions/checkout@v2
+    - name: System Dependencies
+      run: .github/workflows/dependencies/dependencies.sh
+    - name: Repo Dependencies
+      run: Tools/CloneDeps.sh
+    - name: Build
+      env:
+         AMREX_HOME: ${GITHUB_WORKSPACE}/build/amrex
+         IAMR_HOME: ${GITHUB_WORKSPACE}/build/IAMR
+         PELE_PHYSICS_HOME: ${GITHUB_WORKSPACE}/build/PelePhysics
+         PELELM_HOME: ${GITHUB_WORKSPACE}
+      run: |
+        cd Exec/RegTests/EB_FlowPastCylinder/
+        make TPL COMP=gnu DIM=3
+        make -j 2 COMP=gnu DIM=3
+        mpirun -n 4 ./PeleLM3d.gnu.MPI.ex inputs.3d-regt_VS max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -142,13 +142,13 @@ jobs:
          IAMR_HOME: ${GITHUB_WORKSPACE}/build/IAMR
          PELE_PHYSICS_HOME: ${GITHUB_WORKSPACE}/build/PelePhysics
          PELELM_HOME: ${GITHUB_WORKSPACE}
+      working-directory: ./Exec/RegTests/FlameSheet/
       run: |
-        working-directory: Exec/RegTests/FlameSheet/
         make TPL COMP=gnu USE_MPI=FALSE DEBUG=FALSE
         make -j 2 COMP=gnu USE_MPI=FALSE DEBUG=FALSE
     - name: Run
+      working-directory: ./Exec/RegTests/FlameSheet/
       run: |
-        working-directory: Exec/RegTests/FlameSheet/
         ./PeleLM2d.gnu.ex inputs.2d_regt max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0
 
   # Build and Run the CoVo RegTest with GNU7.5 and no MPI support
@@ -169,13 +169,13 @@ jobs:
          IAMR_HOME: ${GITHUB_WORKSPACE}/build/IAMR
          PELE_PHYSICS_HOME: ${GITHUB_WORKSPACE}/build/PelePhysics
          PELELM_HOME: ${GITHUB_WORKSPACE}
+      working-directory: ./Exec/RegTests/PeriodicCases/
       run: |
-        working-directory: Exec/RegTests/PeriodicCases/
         make TPL COMP=gnu USE_MPI=FALSE
         make -j 2 COMP=gnu USE_MPI=FALSE
     - name: Run
+      working-directory: ./Exec/RegTests/PeriodicCases/
       run: |
-        working-directory: Exec/RegTests/PeriodicCases/
         ./PeleLM2d.gnu.ex inputs.2d_CoVo_RegT_negX max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0
   
   # Build and Run the FPC RegTest with GNU7.5 and MPI support
@@ -196,13 +196,13 @@ jobs:
          IAMR_HOME: ${GITHUB_WORKSPACE}/build/IAMR
          PELE_PHYSICS_HOME: ${GITHUB_WORKSPACE}/build/PelePhysics
          PELELM_HOME: ${GITHUB_WORKSPACE}
+      working-directory: ./Exec/RegTests/EB_FlowPastCylinder/
       run: |
-        working-directory: Exec/RegTests/EB_FlowPastCylinder/
         make TPL COMP=gnu
         make -j 2 COMP=gnu
     - name: Run
+      working-directory: ./Exec/RegTests/EB_FlowPastCylinder/
       run: |
-        working-directory: Exec/RegTests/EB_FlowPastCylinder/
         mpirun -n 2 ./PeleLM2d.gnu.MPI.ex inputs.2d-regt_VS max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0
   
   # Build and Run the 3D FPC RegTest with GNU7.5 and MPI support
@@ -223,11 +223,11 @@ jobs:
          IAMR_HOME: ${GITHUB_WORKSPACE}/build/IAMR
          PELE_PHYSICS_HOME: ${GITHUB_WORKSPACE}/build/PelePhysics
          PELELM_HOME: ${GITHUB_WORKSPACE}
+      working-directory: ./Exec/RegTests/EB_FlowPastCylinder/
       run: |
-        working-directory: Exec/RegTests/EB_FlowPastCylinder/
         make TPL COMP=gnu DIM=3
         make -j 2 COMP=gnu DIM=3
     - name: Run
+      working-directory: ./Exec/RegTests/EB_FlowPastCylinder/
       run: |
-        working-directory: Exec/RegTests/EB_FlowPastCylinder/
         mpirun -n 4 ./PeleLM3d.gnu.MPI.ex inputs.3d-regt_VS max_step=2 amr.plot_files_output=0 amr.checkpoint_files_output=0

--- a/Exec/RegTests/EB_FlowPastCylinder/inputs.3d-regt_VS
+++ b/Exec/RegTests/EB_FlowPastCylinder/inputs.3d-regt_VS
@@ -1,8 +1,8 @@
 #----------------------DOMAIN DEFINITION------------------------
 geometry.is_periodic = 0 1 1              # For each dir, 0: non-perio, 1: periodic
 geometry.coord_sys   = 0                  # 0 => cart, 1 => RZ
-geometry.prob_lo     = -0.04 -0.04 0.0    # x_lo y_lo (z_lo)
-geometry.prob_hi     =  0.12  0.04 0.005  # x_hi y_hi (z_hi)
+geometry.prob_lo     = -0.04 -0.04 -0.02  # x_lo y_lo (z_lo)
+geometry.prob_hi     =  0.12  0.04  0.02  # x_hi y_hi (z_hi)
 
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
 # Interior, Inflow, Outflow, Symmetry,


### PR DESCRIPTION
On top of the compilations tests already there, add a few 2-time steps runs:
 - FlameSheet 2D
 - COVO 2D
 - EB FlowPastCylinder 2D
 - EB FlowPastCylinder 3D

All are still in a Ubuntu environment.