### PR TITLE
Feature transport no managed

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -120,9 +120,8 @@ jobs:
         export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
         export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
         cd Exec/RegTests/FlameSheet/
-        make help COMP=gnu USE_CUDA=TRUE
         make TPL COMP=gnu USE_CUDA=TRUE
-        make -j 2 COMP=gnu USE_CUDA=TRUE
+        make -j 2 COMP=gnu USE_CUDA=TRUE CXXFLAGS+=-Xptxas --disable-optimizer-constants 
 
   #Build and run the 2D FlameSheet RegTest with GNU7.5 and no MPI support
   FS2D_NoMPIRun:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -121,7 +121,7 @@ jobs:
         export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
         cd Exec/RegTests/FlameSheet/
         make TPL COMP=gnu USE_CUDA=TRUE
-        make -j 2 COMP=gnu USE_CUDA=TRUE CXXFLAGS+=-Xptxas --disable-optimizer-constants 
+        make -j 2 COMP=gnu USE_CUDA=TRUE CXXFLAGS+=-Xptxas CXXFLAGS+=--disable-optimizer-constants 
 
   #Build and run the 2D FlameSheet RegTest with GNU7.5 and no MPI support
   FS2D_NoMPIRun:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -121,7 +121,7 @@ jobs:
         export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
         cd Exec/RegTests/FlameSheet/
         make TPL COMP=gnu USE_CUDA=TRUE
-        make -j 2 COMP=gnu USE_CUDA=TRUE CXXFLAGS+=-Xptxas CXXFLAGS+=--disable-optimizer-constants 
+        make -j 2 COMP=gnu USE_CUDA=TRUE
 
   #Build and run the 2D FlameSheet RegTest with GNU7.5 and no MPI support
   FS2D_NoMPIRun:

--- a/Exec/RegTests/FlameSheet/GNUmakefile
+++ b/Exec/RegTests/FlameSheet/GNUmakefile
@@ -71,6 +71,10 @@ CEXE_headers +=
 FEXE_headers += 
 
 include $(PELELM_HOME)/Tools/Make/Make.PeleLM
+
+ifeq ($(USE_CUDA),TRUE)
+CXXFLAGS += -Xptxas --disable-optimizer-constants
+endif
 # Available chemistry models:
 # CanuH2 chem-CH4-2step chem-H dme glar gri Hai H-CW header inert Konnov
 # LiDryer Marinov prf_ethanol Roehl sandiego smooke usc

--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -44,6 +44,9 @@
 #endif
 
 #include <reactor.h>
+#ifdef USE_SUNDIALS_PP
+#include <AMReX_SUNMemory.H>
+#endif
 
 #include <Prob_F.H>
 #include <NAVIERSTOKES_F.H>
@@ -324,6 +327,10 @@ void
 PeleLM::Initialize ()
 {
   if (initialized) return;
+
+#ifdef USE_SUNDIALS_PP
+  amrex::sundials::MemoryHelper::Initialize();
+#endif
 
   PeleLM::Initialize_specific();
   

--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -44,8 +44,10 @@
 #endif
 
 #include <reactor.h>
+#ifdef USE_AMREX_GPU
 #ifdef USE_SUNDIALS_PP
 #include <AMReX_SUNMemory.H>
+#endif
 #endif
 
 #include <Prob_F.H>
@@ -328,8 +330,10 @@ PeleLM::Initialize ()
 {
   if (initialized) return;
 
+#ifdef AMREX_USE_GPU
 #ifdef USE_SUNDIALS_PP
   amrex::sundials::MemoryHelper::Initialize();
+#endif
 #endif
 
   PeleLM::Initialize_specific();

--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -1328,8 +1328,33 @@ PeleLM::init_mixture_fraction()
                for (int i=0; i<NUM_SPECIES; ++i) {
                   XF[i] = compositionIn[i];
                }
-               EOS::X2Y(XO, YO);
-               EOS::X2Y(XF, YF);
+               // Here comes the fun part for calling DEVICE functions from HOST
+               amrex::Gpu::DeviceVector<amrex::Real> XO_v(NUM_SPECIES);
+               amrex::Gpu::DeviceVector<amrex::Real> XF_v(NUM_SPECIES);
+               for (int i = 0; i < NUM_SPECIES; i++ ) {
+                  XO_v[i] = XO[i];
+                  XF_v[i] = XF[i];
+               }
+               amrex::Gpu::DeviceVector<amrex::Real> YO_v(NUM_SPECIES);
+               amrex::Gpu::DeviceVector<amrex::Real> YF_v(NUM_SPECIES);
+               amrex::Real* XO_d = XO_v.data();
+               amrex::Real* XF_d = XF_v.data();
+               amrex::Real* YO_d = YO_v.data();
+               amrex::Real* YF_d = YF_v.data();
+               Box dumbx({AMREX_D_DECL(0,0,0)},{AMREX_D_DECL(0,0,0)});
+               amrex::ParallelFor(dumbx, [XO_d,XF_d,YO_d,YF_d]
+               AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+               {
+                  EOS::X2Y(XO_d,YO_d);
+                  EOS::X2Y(XF_d,YF_d);
+               });
+#if AMREX_USE_GPU
+               amrex::Gpu::dtoh_memcpy(YO,YO_d,sizeof(amrex::Real)*NUM_SPECIES);
+               amrex::Gpu::dtoh_memcpy(YF,YF_d,sizeof(amrex::Real)*NUM_SPECIES);
+#else
+               std::memcpy(YO,YO_d,sizeof(amrex::Real)*NUM_SPECIES);
+               std::memcpy(YF,YF_d,sizeof(amrex::Real)*NUM_SPECIES);
+#endif
             } else {
                Abort("Unknown mixtureFraction.type ! Should be 'mass' or 'mole'");
             }
@@ -9104,7 +9129,24 @@ PeleLM::parseComposition(Vector<std::string> compositionIn,
          massFrac[i] = compoIn[i];
       }
    } else if ( compositionType == "mole" ) {         // mole
-      EOS::X2Y(compoIn,massFrac);
+      amrex::Gpu::DeviceVector<amrex::Real> compIn_v(NUM_SPECIES);
+      for (int i = 0; i < NUM_SPECIES; i++ ) {
+         compIn_v[i] = compoIn[i];
+      }
+      amrex::Gpu::DeviceVector<amrex::Real> massFrac_v(NUM_SPECIES);
+      amrex::Real* compIn_d = compIn_v.data();
+      amrex::Real* massFrac_d = massFrac_v.data();
+      Box dumbx({AMREX_D_DECL(0,0,0)},{AMREX_D_DECL(0,0,0)});
+      amrex::ParallelFor(dumbx, [compIn_d,massFrac_d]
+      AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+      {
+         EOS::X2Y(compIn_d,massFrac_d);
+      });
+#if AMREX_USE_GPU
+      amrex::Gpu::dtoh_memcpy(massFrac,massFrac_d,sizeof(amrex::Real)*NUM_SPECIES);
+#else
+      std::memcpy(massFrac,massFrac_d,sizeof(amrex::Real)*NUM_SPECIES);
+#endif
    } else {
       Abort("Unknown mixtureFraction.type ! Should be 'mass' or 'mole'");
    }

--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -44,7 +44,7 @@
 #endif
 
 #include <reactor.h>
-#ifdef USE_AMREX_GPU
+#ifdef AMREX_USE_GPU
 #ifdef USE_SUNDIALS_PP
 #include <AMReX_SUNMemory.H>
 #endif

--- a/Source/PeleLM_K.H
+++ b/Source/PeleLM_K.H
@@ -8,6 +8,7 @@
 #include <EOS.H>
 #include <Transport.H>
 #include <cmath>
+#include <TransportParams.H>
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
@@ -384,7 +385,8 @@ getTransportCoeff(int i, int j, int k,
                   amrex::Array4<const amrex::Real> const& T,
                   amrex::Array4<      amrex::Real> const& rhoDi,
                   amrex::Array4<      amrex::Real> const& lambda,
-                  amrex::Array4<      amrex::Real> const& mu) noexcept
+                  amrex::Array4<      amrex::Real> const& mu,
+                  TransParm const* trans_parm) noexcept
 {
    using namespace amrex::literals;
 
@@ -418,7 +420,7 @@ getTransportCoeff(int i, int j, int k,
    bool get_lam = true;
    bool get_Ddiag = true;
    transport(get_xi, get_mu, get_lam, get_Ddiag, Tloc,
-             rho, y, rhoDi_cgs, mu_cgs, dummy_xi, lambda_cgs);
+             rho, y, rhoDi_cgs, mu_cgs, dummy_xi, lambda_cgs, trans_parm);
 
    // Do CGS -> MKS conversions
    for (int n = 0; n < NUM_SPECIES; n++) {
@@ -438,7 +440,8 @@ getTransportCoeffUnityLe(int i, int j, int k,
                          amrex::Array4<      amrex::Real> const& T,
                          amrex::Array4<      amrex::Real> const& rhoDi,
                          amrex::Array4<      amrex::Real> const& lambda,
-                         amrex::Array4<      amrex::Real> const& mu) noexcept
+                         amrex::Array4<      amrex::Real> const& mu,
+                         TransParm const* trans_parm) noexcept
 {
    using namespace amrex::literals;
 
@@ -465,7 +468,7 @@ getTransportCoeffUnityLe(int i, int j, int k,
    bool get_lam = false;
    bool get_Ddiag = false;
    transport(get_xi, get_mu, get_lam, get_Ddiag, T(i,j,k),
-             rho, y, rhoDi_cgs, mu_cgs, dummy_xi, lambda_cgs);
+             rho, y, rhoDi_cgs, mu_cgs, dummy_xi, lambda_cgs, trans_parm);
 
    mu(i,j,k) = mu_cgs * 1.0e-1_rt;                       // CGS -> MKS conversions
    for (int n = 0; n < NUM_SPECIES; n++) {
@@ -505,7 +508,8 @@ void
 getVelViscosity(int i, int j, int k,
                 amrex::Array4<const amrex::Real> const& rhoY,
                 amrex::Array4<      amrex::Real> const& T,
-                amrex::Array4<      amrex::Real> const& mu) noexcept
+                amrex::Array4<      amrex::Real> const& mu,
+                TransParm const* trans_parm) noexcept
 {
    using namespace amrex::literals;
 
@@ -532,7 +536,7 @@ getVelViscosity(int i, int j, int k,
    bool get_lam = false;
    bool get_Ddiag = false;
    transport(get_xi, get_mu, get_lam, get_Ddiag, T(i,j,k),
-             rho, y, dummy_rhoDi, mu_cgs, dummy_xi, dummy_lambda);
+             rho, y, dummy_rhoDi, mu_cgs, dummy_xi, dummy_lambda, trans_parm);
 
    // Do CGS -> MKS conversions
    mu(i,j,k) = mu_cgs * 1.0e-1_rt;
@@ -544,7 +548,8 @@ void
 getConductivity(int i, int j, int k,
                 amrex::Array4<const amrex::Real> const& rhoY,
                 amrex::Array4<      amrex::Real> const& T,
-                amrex::Array4<      amrex::Real> const& lambda) noexcept
+                amrex::Array4<      amrex::Real> const& lambda,
+                TransParm const* trans_parm) noexcept
 {
    using namespace amrex::literals;
 
@@ -571,7 +576,7 @@ getConductivity(int i, int j, int k,
    bool get_lam = true;
    bool get_Ddiag = false;
    transport(get_xi, get_mu, get_lam, get_Ddiag, T(i,j,k),
-             rho, y, dummy_rhoDi, dummy_mu, dummy_xi, lambda_cgs);
+             rho, y, dummy_rhoDi, dummy_mu, dummy_xi, lambda_cgs, trans_parm);
 
    // Do CGS -> MKS conversions
    lambda(i,j,k) = lambda_cgs * 1.0e-5_rt;


### PR DESCRIPTION
Update PeleLM to comply with recent changes in PelePhysics:
 - EOS calls from host are wrapped in lambdas
 - TranParm pointer is passed in transport coefficient functions
 - SUNMemory initialize is added to PeleLM:Initialize for when using Sundials