### PR TITLE
Enabling SRD in PeleLM

### DIFF
--- a/Source/PeleLM.H
+++ b/Source/PeleLM.H
@@ -286,7 +286,6 @@ public:
                          int                     scalScomp,
                          const amrex::MFIter&    mfi) override;
 
-
   virtual void mac_sync () override;
   //
   // Crse/fine fixup functions.
@@ -411,20 +410,32 @@ public:
                                FluxBoxes&  fb_betan, 
                                FluxBoxes&  fb_betanp1);
 
-  void flux_divergence (amrex::MultiFab&        fdiv,
-                        int              fdivComp,
-                        const amrex::MultiFab* const* extensive_fluxes,
-                        int              fluxComp,
-                        int              nComp,
-                        amrex::Real             scale) const;
+  void flux_divergenceRD (const amrex::MultiFab  &a_state,
+                          int                     stateComp,
+                          amrex::MultiFab        &a_divergence,
+                          int                     divComp,
+                          const amrex::MultiFab* const* extensive_fluxes,
+                          int                     fluxComp,
+                          int                     nComp,
+                          amrex::BCRec const*     d_bc,
+                          amrex::Real             scale,
+                          amrex::Real             a_dt,
+                          int areSpeciesFluxes = 0);
 
-  void getDiffusivity (amrex::MultiFab* diffusivity[BL_SPACEDIM],
+  void flux_divergence (amrex::MultiFab&  a_divergence,
+                        int               divComp,
+                        const amrex::MultiFab* const* a_ext_fluxes,
+                        int               fluxComp,
+                        int               nComp,
+                        amrex::Real       scale);
+
+  void getDiffusivity (amrex::MultiFab* diffusivity[AMREX_SPACEDIM],
                        const amrex::Real time,
                        const int state_comp,
                        const int dst_comp,
                        const int num_comp);
 
-  void getDiffusivity_Wbar (amrex::MultiFab* diffusivity[BL_SPACEDIM],
+  void getDiffusivity_Wbar (amrex::MultiFab* diffusivity[AMREX_SPACEDIM],
                             const amrex::Real time);
 
   amrex::DistributionMapping getFuncCountDM (const amrex::BoxArray& bxba, int ngrow);
@@ -705,6 +716,10 @@ public:
   static int         iter_debug;
   static int         mHtoTiterMAX;
   static amrex::Vector<amrex::Real> mTmpData;
+
+#ifdef AMREX_USE_EB
+  static std::string diffusion_redistribution_type;
+#endif
   
 
   static int  ncells_chem;

--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -4392,7 +4392,6 @@ PeleLM::flux_divergenceRD(const MultiFab        &a_state,
                           int areSpeciesFluxes)
 {
 #ifdef AMREX_USE_EB
-   AMREX_ASSERT(a_divergence.nGrow() >= 1);
    // Temporary divTemp to allow fillBoundary
    MultiFab divTemp(grids,dmap,nComp,a_state.nGrow(),MFInfo(),Factory());
    divTemp.setVal(0.0);
@@ -7731,7 +7730,6 @@ PeleLM::differential_spec_diffuse_sync (Real dt,
    // Ssync = "RHS from diffusion solve" + (dt*sdc_theta)*div(delta Gamma)
    //
    // Recompute update with adjusted diffusion fluxes
-   // TODO : this is not redistributed ...
    //
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -8234,7 +8232,7 @@ PeleLM::calc_divu (Real      time,
 {
    BL_PROFILE("PLM::calc_divu()");
 
-   const int nGrow = 1;
+   const int nGrow = 0;
    int vtCompT = NUM_SPECIES + 1;
    int vtCompY = 0;
    MultiFab mcViscTerms(grids,dmap,NUM_SPECIES+2,nGrow,MFInfo(),Factory());

--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -2079,6 +2079,7 @@ PeleLM::initData ()
   // This changes the input velocity fields
   //
   InitialRedistribution();
+  set_body_state(S_new);
 #endif
 
   //
@@ -4394,6 +4395,7 @@ PeleLM::flux_divergenceRD(const MultiFab        &a_state,
    AMREX_ASSERT(a_divergence.nGrow() >= 1);
    // Temporary divTemp to allow fillBoundary
    MultiFab divTemp(grids,dmap,nComp,a_state.nGrow(),MFInfo(),Factory());
+   divTemp.setVal(0.0);
 
    // Call face-centroid extensive fluxes divergence with scaling
    flux_divergence(divTemp, 0, a_fluxes, fluxComp, nComp, scale);


### PR DESCRIPTION
This PR update the flux divergence function of LM to enable switching between SRD/FRD/NoRedist and replace the previous implementation of redistribution.
Ultimately, the redistribution in LM is as follows:
 - explicit advective fluxes are redistributed using the redistribution scheme controlled by `ns.redistribution_type`
 - explicit diffusive fluxes are redistributed using the redistribution scheme controlled by `ns.diffusion_redistribution_type`
 - implicit diffusive fluxes are not redistributed (species semi-implicit solve, velocity tensor solve)
 
In practice, SRD or NewSRD should be used for explicit advective fluxes and FRD should be used for explicit diffusive fluxes. The later is recommended since it conserves some nice properties of the explicit diffusion update (sum of species update equal zero, consistency between species/differential diffusion update). The former is not yet the default, IAMR will need to be updated.

An inconsistency remains pertaining to the cell-center/cell-centroid duality: MLMG solves still assumes the solution lives on the cell-center since `phi_on_centroid` is not available. One will need to update the operators (in IAMR) when this option is finalized.