### PR TITLE
In derived mag vorticity, put the result in dcomp of the derived

### DIFF
--- a/Exec/RegTests/EB_FlamePastCylinder/inputs.2d-regt
+++ b/Exec/RegTests/EB_FlamePastCylinder/inputs.2d-regt
@@ -90,7 +90,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -116,9 +115,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/EB_FlamePastCylinder/inputs.2d-regt
+++ b/Exec/RegTests/EB_FlamePastCylinder/inputs.2d-regt
@@ -111,23 +111,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/EB_FlamePastCylinder/inputs.3d-regt
+++ b/Exec/RegTests/EB_FlamePastCylinder/inputs.3d-regt
@@ -119,23 +119,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-11     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-11 
-proj.sync_tol            = 1.0e-11     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-11     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-11     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-11
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/EB_FlamePastCylinder/inputs.3d-regt
+++ b/Exec/RegTests/EB_FlamePastCylinder/inputs.3d-regt
@@ -98,7 +98,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -124,9 +123,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_EulerVS
+++ b/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_EulerVS
@@ -107,23 +107,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_EulerVS
+++ b/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_EulerVS
@@ -86,7 +86,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -112,9 +111,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_VS
+++ b/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_VS
@@ -107,23 +107,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_VS
+++ b/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_VS
@@ -86,7 +86,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -112,9 +111,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_VS2Cyl
+++ b/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_VS2Cyl
@@ -108,23 +108,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_VS2Cyl
+++ b/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_VS2Cyl
@@ -87,7 +87,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -113,9 +112,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_VSGodunov
+++ b/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_VSGodunov
@@ -108,23 +108,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_VSGodunov
+++ b/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_VSGodunov
@@ -87,7 +87,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -113,9 +112,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_WS
+++ b/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_WS
@@ -110,23 +110,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_WS
+++ b/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_WS
@@ -89,7 +89,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -115,9 +114,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_WT
+++ b/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_WT
@@ -110,23 +110,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_WT
+++ b/Exec/RegTests/EB_FlowPastCylinder/inputs.2d-regt_WT
@@ -89,7 +89,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -115,9 +114,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/EB_FlowPastCylinder/inputs.3d-regt_VS
+++ b/Exec/RegTests/EB_FlowPastCylinder/inputs.3d-regt_VS
@@ -88,7 +88,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -114,9 +113,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/EB_FlowPastCylinder/inputs.3d-regt_VS
+++ b/Exec/RegTests/EB_FlowPastCylinder/inputs.3d-regt_VS
@@ -109,23 +109,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/FlameSheet/inputs.2d-convergence
+++ b/Exec/RegTests/FlameSheet/inputs.2d-convergence
@@ -109,7 +109,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -135,9 +134,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/FlameSheet/inputs.2d-convergence
+++ b/Exec/RegTests/FlameSheet/inputs.2d-convergence
@@ -130,23 +130,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/FlameSheet/inputs.2d-regt
+++ b/Exec/RegTests/FlameSheet/inputs.2d-regt
@@ -109,7 +109,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -135,9 +134,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/FlameSheet/inputs.2d-regt
+++ b/Exec/RegTests/FlameSheet/inputs.2d-regt
@@ -130,23 +130,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/FlameSheet/inputs.2d-regt_GPU
+++ b/Exec/RegTests/FlameSheet/inputs.2d-regt_GPU
@@ -109,7 +109,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -135,9 +134,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/FlameSheet/inputs.2d-regt_GPU
+++ b/Exec/RegTests/FlameSheet/inputs.2d-regt_GPU
@@ -130,23 +130,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/FlameSheet/inputs.2d-restartTest
+++ b/Exec/RegTests/FlameSheet/inputs.2d-restartTest
@@ -109,7 +109,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -135,9 +134,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/FlameSheet/inputs.2d-restartTest
+++ b/Exec/RegTests/FlameSheet/inputs.2d-restartTest
@@ -130,23 +130,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/FlameSheet/inputs.3d-regt
+++ b/Exec/RegTests/FlameSheet/inputs.3d-regt
@@ -109,7 +109,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -135,9 +134,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/FlameSheet/inputs.3d-regt
+++ b/Exec/RegTests/FlameSheet/inputs.3d-regt
@@ -130,23 +130,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/FlameSheet/inputs.3d-regt_GPU
+++ b/Exec/RegTests/FlameSheet/inputs.3d-regt_GPU
@@ -109,7 +109,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -135,9 +134,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/FlameSheet/inputs.3d-regt_GPU
+++ b/Exec/RegTests/FlameSheet/inputs.3d-regt_GPU
@@ -130,23 +130,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/FlameSheet/inputs.3d-regt_GPUdodecane
+++ b/Exec/RegTests/FlameSheet/inputs.3d-regt_GPUdodecane
@@ -132,23 +132,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-11     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-11 
-proj.sync_tol            = 1.0e-11     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-11     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-11     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-11
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/FlameSheet/inputs.3d-regt_GPUdodecane
+++ b/Exec/RegTests/FlameSheet/inputs.3d-regt_GPUdodecane
@@ -111,7 +111,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -137,9 +136,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/FlameSheet/inputs.3d-regt_GPUdodecaneLu
+++ b/Exec/RegTests/FlameSheet/inputs.3d-regt_GPUdodecaneLu
@@ -132,23 +132,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-11     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-11 
-proj.sync_tol            = 1.0e-11     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-11     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-11     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-11
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/FlameSheet/inputs.3d-regt_GPUdodecaneLu
+++ b/Exec/RegTests/FlameSheet/inputs.3d-regt_GPUdodecaneLu
@@ -111,7 +111,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -137,9 +136,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/FlameSheet/inputs.3d-regt_GPUheptane
+++ b/Exec/RegTests/FlameSheet/inputs.3d-regt_GPUheptane
@@ -110,7 +110,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -136,9 +135,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/FlameSheet/inputs.3d-regt_GPUheptane
+++ b/Exec/RegTests/FlameSheet/inputs.3d-regt_GPUheptane
@@ -131,23 +131,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-11     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-11 
-proj.sync_tol            = 1.0e-11     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-11     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-11     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-11
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/HIT/inputs.3d
+++ b/Exec/RegTests/HIT/inputs.3d
@@ -80,7 +80,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -106,9 +105,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/HIT/inputs.3d
+++ b/Exec/RegTests/HIT/inputs.3d
@@ -101,23 +101,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoGauSpec_Conv_neg45d
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoGauSpec_Conv_neg45d
@@ -112,23 +112,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoGauSpec_Conv_neg45d
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoGauSpec_Conv_neg45d
@@ -91,7 +91,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -117,9 +116,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoGauSpec_RegT_AMR
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoGauSpec_RegT_AMR
@@ -84,7 +84,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -110,9 +109,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoGauSpec_RegT_AMR
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoGauSpec_RegT_AMR
@@ -105,23 +105,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoGauSpec_RegT_negY
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoGauSpec_RegT_negY
@@ -84,7 +84,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -110,9 +109,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoGauSpec_RegT_negY
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoGauSpec_RegT_negY
@@ -105,23 +105,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoGauSpec_RegT_posY
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoGauSpec_RegT_posY
@@ -84,7 +84,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -110,9 +109,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoGauSpec_RegT_posY
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoGauSpec_RegT_posY
@@ -105,23 +105,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoGauTemp_Conv_pos45d
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoGauTemp_Conv_pos45d
@@ -84,7 +84,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -110,9 +109,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoGauTemp_Conv_pos45d
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoGauTemp_Conv_pos45d
@@ -105,23 +105,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoGauTemp_RegT_AMR
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoGauTemp_RegT_AMR
@@ -84,7 +84,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -110,9 +109,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoGauTemp_RegT_AMR
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoGauTemp_RegT_AMR
@@ -105,23 +105,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_Conv_AMR
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_Conv_AMR
@@ -104,23 +104,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_Conv_AMR
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_Conv_AMR
@@ -83,7 +83,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -109,9 +108,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_Conv_pos45d
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_Conv_pos45d
@@ -104,23 +104,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_Conv_pos45d
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_Conv_pos45d
@@ -83,7 +83,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -109,9 +108,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_AMR
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_AMR
@@ -104,23 +104,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_AMR
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_AMR
@@ -83,7 +83,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -109,9 +108,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_AMR_Simple
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_AMR_Simple
@@ -77,7 +77,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
  -
@@ -103,9 +102,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_AMR_Simple
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_AMR_Simple
@@ -98,23 +98,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_negX
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_negX
@@ -104,23 +104,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_negX
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_negX
@@ -83,7 +83,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -109,9 +108,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_posX
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_posX
@@ -104,23 +104,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_posX
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_posX
@@ -83,7 +83,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -109,9 +108,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_posX_Tiling
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_posX_Tiling
@@ -104,23 +104,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_posX_Tiling
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_CoVo_RegT_posX_Tiling
@@ -83,7 +83,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -109,9 +108,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/PeriodicCases/inputs.2d_DiffGauSpec_RegT_AMR
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_DiffGauSpec_RegT_AMR
@@ -84,7 +84,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -110,9 +109,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/PeriodicCases/inputs.2d_DiffGauSpec_RegT_AMR
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_DiffGauSpec_RegT_AMR
@@ -105,23 +105,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.2d_DiffGauTemp_RegT_AMR
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_DiffGauTemp_RegT_AMR
@@ -84,7 +84,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -110,9 +109,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/PeriodicCases/inputs.2d_DiffGauTemp_RegT_AMR
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_DiffGauTemp_RegT_AMR
@@ -105,23 +105,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.2d_DiffGauTemp_RegT_AMR_2
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_DiffGauTemp_RegT_AMR_2
@@ -84,7 +84,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -110,9 +109,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/PeriodicCases/inputs.2d_DiffGauTemp_RegT_AMR_2
+++ b/Exec/RegTests/PeriodicCases/inputs.2d_DiffGauTemp_RegT_AMR_2
@@ -105,23 +105,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.3d_CoVo_RegT_AMR
+++ b/Exec/RegTests/PeriodicCases/inputs.3d_CoVo_RegT_AMR
@@ -83,7 +83,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -110,9 +109,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/PeriodicCases/inputs.3d_CoVo_RegT_AMR
+++ b/Exec/RegTests/PeriodicCases/inputs.3d_CoVo_RegT_AMR
@@ -105,23 +105,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.3d_CoVo_RegT_posX
+++ b/Exec/RegTests/PeriodicCases/inputs.3d_CoVo_RegT_posX
@@ -104,23 +104,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 #fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.3d_CoVo_RegT_posX
+++ b/Exec/RegTests/PeriodicCases/inputs.3d_CoVo_RegT_posX
@@ -83,7 +83,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -109,9 +108,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Exec/RegTests/PeriodicCases/inputs.3d_CoVo_RegT_posX_Tiling
+++ b/Exec/RegTests/PeriodicCases/inputs.3d_CoVo_RegT_posX_Tiling
@@ -104,23 +104,22 @@ diffuse.tensor_max_order = 4
 diffuse.v                = 0
 
 # ------------------  INPUTS TO PROJECTION CLASS -------------------
-proj.proj_tol            = 1.0e-12     # tolerence for projections
-proj.proj_abs_tol        = 1.0e-12 
-proj.sync_tol            = 1.0e-12     # tolerence for projections
-proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
-proj.do_outflow_bcs      = 0
-proj.divu_minus_s_factor = .5
-proj.divu_minus_s_factor = 0.
-proj.proj_2              = 1
-nodal_proj.verbose       = 0
-proj.v                   = 0
+nodal_proj.proj_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.proj_abs_tol        = 1.0e-12 
+nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
+nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
+nodal_proj.do_outflow_bcs      = 0
+nodal_proj.divu_minus_s_factor = .5
+nodal_proj.divu_minus_s_factor = 0.
+nodal_proj.proj_2              = 1
+nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------
-mac.mac_tol              = 1.0e-12     # tolerence for mac projections
-mac.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
-mac.mac_abs_tol          = 1.0e-12
-mac.do_outflow_bcs       = 0
-mac.v                    = 0
+mac_proj.mac_tol              = 1.0e-12     # tolerence for mac projections
+mac_proj.mac_sync_tol         = 1.0e-12     # tolerence for mac SYNC projection
+mac_proj.mac_abs_tol          = 1.0e-12
+mac_proj.do_outflow_bcs       = 0
+mac_proj.verbose              = 0
 
 #--------------------------OMP TILE INPUTS-----------------------------
 fabarray.mfiter_tile_size = 8 8 8

--- a/Exec/RegTests/PeriodicCases/inputs.3d_CoVo_RegT_posX_Tiling
+++ b/Exec/RegTests/PeriodicCases/inputs.3d_CoVo_RegT_posX_Tiling
@@ -83,7 +83,6 @@ ns.sum_interval      = 5               # timesteps between computing mass
 ns.do_reflux         = 1               # 1 => do refluxing
 ns.do_mac_proj       = 1               # 1 => do MAC projection
 ns.do_sync_proj      = 1               # 1 => do Sync Project
-ns.divu_relax_factor = 0.0
 ns.be_cn_theta       = 0.5
 ns.do_temp           = 1
 ns.do_diffuse_sync   = 1
@@ -109,9 +108,6 @@ nodal_proj.proj_abs_tol        = 1.0e-12
 nodal_proj.sync_tol            = 1.0e-12     # tolerence for projections
 nodal_proj.rho_wgt_vel_proj    = 0           # 0 => const den proj, 1 => rho weighted
 nodal_proj.do_outflow_bcs      = 0
-nodal_proj.divu_minus_s_factor = .5
-nodal_proj.divu_minus_s_factor = 0.
-nodal_proj.proj_2              = 1
 nodal_proj.verbose             = 0
 
 # ------------------  INPUTS TO MACPROJ CLASS -------------------

--- a/Source/PeleLM_derive.cpp
+++ b/Source/PeleLM_derive.cpp
@@ -710,7 +710,7 @@ void pelelm_dcma (const Box& bx, FArrayBox& derfab, int dcomp, int ncomp,
 //
 //  Compute vorticity
 //
-void pelelm_mgvort (const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp*/,
+void pelelm_mgvort (const Box& bx, FArrayBox& derfab, int dcomp, int /*ncomp*/,
                     const FArrayBox& datfab, const Geometry& geomdata,
                     Real /*time*/, const int* /*bcrec*/, int /*level*/)
 
@@ -723,7 +723,7 @@ void pelelm_mgvort (const Box& bx, FArrayBox& derfab, int /*dcomp*/, int /*ncomp
                  const amrex::Real idz = geomdata.InvCellSize(2););
 
     amrex::Array4<amrex::Real const> const& dat_arr = datfab.const_array();
-    amrex::Array4<amrex::Real>       const&vort_arr = derfab.array();
+    amrex::Array4<amrex::Real>       const&vort_arr = derfab.array(dcomp);
 
 #ifdef AMREX_USE_EB
     const EBFArrayBox& ebfab = static_cast<EBFArrayBox const&>(datfab);


### PR DESCRIPTION
array, rather than assuming comp==0.

The `mgvort` routine had been lifted into IAMR and caused a problem there, where mag vort ended up overwriting x_velocity in the plotfile.