### PR TITLE
Explicitly call pmf_data.deallocate() during variableCleanUp.

### DIFF
--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -935,7 +935,7 @@ PeleLM::variableCleanUp ()
    The_Arena()->free(ac_parm_d);
    trans_parms.deallocate();
 
-   //PMF::close();
+   pmf_data.deallocate();
 
    m_reactor->close();
 }


### PR DESCRIPTION
Along with [PelePhysics PR#220](https://github.com/AMReX-Combustion/PelePhysics/pull/229) this fixes issue #211 