### PR TITLE
bug fixes for unity Le

### DIFF
--- a/Source/PeleLM.cpp
+++ b/Source/PeleLM.cpp
@@ -1039,7 +1039,7 @@ PeleLM::define_data ()
    raii_fbs.push_back(std::unique_ptr<FluxBoxes>{new FluxBoxes(this, nEdgeStates, nGrowEdges)});
    EdgeFlux  = raii_fbs.back()->get();
 
-   if (NUM_SPECIES>0 && !unity_Le)
+   if (NUM_SPECIES>0)
    {
      raii_fbs.push_back(std::unique_ptr<FluxBoxes>{new FluxBoxes(this, NUM_SPECIES+3, nGrow)});
      SpecDiffusionFluxn   = raii_fbs.back()->get();

--- a/Source/PeleLM_K.H
+++ b/Source/PeleLM_K.H
@@ -502,7 +502,7 @@ getTransportCoeffUnityLe(int i, int j, int k,
 
    amrex::Real cpmix = 0.0_rt;
    eos.TY2Cp(T(i,j,k), y, cpmix);
-   lambda(i,j,k) = mu_cgs * 1.0e-1_rt * PrInv * cpmix;   // Constant Prandtl number
+   lambda(i,j,k) = (mu_cgs * 1.0e-1_rt) * PrInv * (cpmix * 1.0e-4_rt);   // Constant Prandtl number + unit conversions
 }
 
 AMREX_GPU_HOST_DEVICE

--- a/Source/PeleLM_derive.cpp
+++ b/Source/PeleLM_derive.cpp
@@ -421,12 +421,21 @@ void pelelm_dertransportcoeff (const Box& bx, FArrayBox& derfab, int dcomp, int 
 
     // Get the transport GPU data pointer
     auto const* ltransparm = PeleLM::trans_parms.device_trans_parm();
-
-    amrex::ParallelFor(bx,
-    [T, rhoY, rhoD, lambda, mu, ltransparm] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-    {
-        getTransportCoeff( i, j, k, rhoY, T, rhoD, lambda, mu, ltransparm);
-    });
+    if ( PeleLM::unity_Le ) {
+      amrex::Real ScInv = 1.0/PeleLM::schmidt;
+      amrex::Real PrInv = 1.0/PeleLM::prandtl;
+      amrex::ParallelFor(bx,
+			 [T, rhoY, rhoD, lambda, mu, ScInv, PrInv, ltransparm] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+      {
+	getTransportCoeffUnityLe( i, j, k, ScInv, PrInv, rhoY, T, rhoD, lambda, mu, ltransparm);
+      });
+    } else {
+      amrex::ParallelFor(bx,
+      [T, rhoY, rhoD, lambda, mu, ltransparm] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+      {
+          getTransportCoeff( i, j, k, rhoY, T, rhoD, lambda, mu, ltransparm);
+      });
+    }
 
 }
 


### PR DESCRIPTION
A few things I bumped into when I activated this option while debugging something else:

- Current code segfaults because unity Le skips some initialization (it wasn't clear to me why this should be skipped for unity Le)
- Missed CGS -> MKS conversion for Cp
- Change derives to derive the transport unity Le transport coefficients when using unity Le